### PR TITLE
feat(customer-orders-ui): add customer orders

### DIFF
--- a/client/src/AppRoutes.tsx
+++ b/client/src/AppRoutes.tsx
@@ -26,6 +26,7 @@ import FarmerProfile from './features/farmer/components/FarmerProfile';
 // import FarmerSettings from './features/farmer/components/FarmerSettings';
 
 import CustomerProfile from './features/customer/components/CustomerProfile';
+import CustomerOrders from './features/customer/components/CustomerOrders';
 
 import { ModalProvider } from './features/shared/context/ModalContext';
 
@@ -144,7 +145,7 @@ const AppRouter: FC = () => {
             ),
             children: [
                 {path:'profile', element: <CustomerProfile/>},  
-                // {path:'orders', element: <CustomerOrders />}, 
+                {path:'orders', element: <CustomerOrders />}, 
                 // {path:'wishlist', element: <CustomerWishlist />}, 
                 {path:'settings', element: <Settings/>}, 
             ]

--- a/client/src/assets/download.svg
+++ b/client/src/assets/download.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="18" viewBox="0 0 16 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 12.75V15.3C1 15.7509 1.17911 16.1833 1.49792 16.5021C1.81673 16.8209 2.24913 17 2.7 17H14.6C15.0509 17 15.4833 16.8209 15.8021 16.5021C16.1209 16.1833 16.3 15.7509 16.3 15.3V12.75M5.25 8.5L8.65 11.9M8.65 11.9L12.05 8.5M8.65 11.9V0" stroke="black" stroke-opacity="0.7" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/features/customer/components/CustomerOrders.tsx
+++ b/client/src/features/customer/components/CustomerOrders.tsx
@@ -1,0 +1,186 @@
+import { FC, ReactElement, useState, useEffect, ChangeEvent } from 'react';
+import toast from 'react-hot-toast';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { useNavigate } from 'react-router-dom';
+import { useAppSelector } from '../../../store/store';
+import { useCancelOrderMutation } from '../../order/order.service';
+import { useGetOrdersByCustomerIDQuery } from '../../order/order.service';
+import { ReduxStateInterface } from '../../../store/store.interface';
+import { OrderDocumentInterface } from '../../order/order.interface';
+import { mapOrderCustomerStatusToUILabel, getCustomerOrderBackgroundColor, formatOrderDate } from '../../shared/utils/utilsFunctions';
+import LoadingSpinner from '../../shared/page/LoadingSpinner';
+import SelectField from '../../shared/inputs/SelectField';
+
+import DownloadIcon from '../../../assets/download.svg';
+
+const CustomerOrders:FC = ():ReactElement => {
+    const navigate = useNavigate();
+    const authUser = useAppSelector((state: ReduxStateInterface) => state.authUser)
+    const customerID = authUser.id;
+
+    const [orders, setOrders] = useState<OrderDocumentInterface[]>([]);
+    const [sort, setSort] = useState<string>('newest');
+
+
+    const { data, isLoading } = useGetOrdersByCustomerIDQuery(
+        customerID ?? skipToken
+    );
+
+    const [cancelOrder] = useCancelOrderMutation();
+
+    useEffect(() => {
+        if (data?.orders) {
+            setOrders(data.orders);
+        }
+    }, [data]);
+
+    console.log("customer orders: ", orders);
+    
+    if (isLoading) {
+        return (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-white ">
+                <div className="text-xl font-semibold">
+                    <LoadingSpinner spinnerClassName='text-gray-800' />
+                </div>
+            </div>
+        );
+    }
+
+    //Mapping backend order_status values to user-friendly UI labels:
+    // 'pending' -> 'Requested'
+    // 'accepted' -> 'In Progress'
+    // 'processing' -> 'In Progress'
+    // 'shipped' -> 'In Progress'
+    // 'completed' -> 'Delivered'
+    // 'rejected' or 'cancel' -> 'canceled'
+
+    const sortSelectOptions = [
+        { label: 'Newest', value: 'newest' },
+        { label: 'Oldest', value: 'oldest' },
+        { label: 'Requested', value: 'requested' },
+        { label: 'In Progress', value: 'inProgress' },
+        { label: 'Delivered', value: 'delivered' },
+        { label: 'Canceled ', value: 'canceled' },
+    ]
+
+    const onCancelRequestedOrder = async(orderID: string):Promise<void> => {
+        try{    
+            const result = await cancelOrder(orderID);
+    
+            const resultMessage = result?.data?.message;
+            toast.success(resultMessage ?? `Order successfully canceled`);
+
+            setOrders(prev =>
+                prev.map(order =>
+                    order.order_id === orderID
+                        ? { ...order, order_status: 'canceled' }
+                        : order
+                )
+            )
+            //Socket - notify farmer on Cancel order
+        } 
+        catch(err){
+            console.error('Error changing status:', err);
+            toast.error("Error on cancel order")
+        }
+    }
+
+    return (
+        <div className='w-full'>
+            <h3 className='hidden sm:block text-xl font-medium ml-3 '>
+                Orders
+            </h3>
+
+            <div className='mt-5 w-full max-w-[800px] mx-auto'>
+                <div className='w-full flex justify-end gap-x-4'>
+                    <SelectField
+                        className={`p-[12px] max-w-[11em] pl-4a bg-white text-gray-500 rounded-xl`}
+                        id='sort'
+                        name='sort'
+                        value={sort || ''}
+                        options={sortSelectOptions}
+                        onChange={(e:ChangeEvent<HTMLSelectElement>) => setSort((e.target.value))}
+                    />
+                </div>
+            </div>
+
+            <div className='mt-8 w-full'>
+
+                {orders.map(order => (
+                    <div className='flex flex-col text-sm xs:text-base font-lato max-w-[800px] mx-auto gap-y-2 px-2 sm:px-4 py-3 mb-6 border border-greyB rounded-md'>
+
+                        <div className='flex justify-between text-gray-600 font-light'>
+                            <div>OrderID: <span className='font-semibold text-black'>#{order.order_id.slice(0,8)}</span></div>
+                            <div className='flex items-center gap-x-2 cursor-pointer hover:border-b hover:border-greyB '>
+                                <img 
+                                    className='w-3'
+                                    src={DownloadIcon}
+                                    alt='downloadIcon'
+                                />
+                                <div className='text-sm sm:text-base'> Download Invoice</div>
+                            </div>
+                        </div>
+
+                        <div className='py-2 sm:px-6 md:px-0 flex flex-cola xs:flex-row gap-x-3 xs:gap-x-4 border-b items-center '>
+                            <div className={`
+                                    py-[.5em] px-3 rounded text-xs font-semibold text-white 
+                                    xs:px-3 xs:text-sm  
+                                    ${getCustomerOrderBackgroundColor(order.order_status)}
+                                `}>
+                                {mapOrderCustomerStatusToUILabel(order.order_status)}
+                            </div>
+
+                            <div className='
+                                flex flex-col font-medium border-greyB  gap-y-2 
+                                md:flex-row md:gap-x-4 
+                            '>
+                                <div className='border-l-2 border-greyB pl-2' >Order Date: <span className='font-light'>{formatOrderDate(order.created_at)}</span> </div>
+                                <div className='border-l-2 border-greyB pl-2 md:pl-0 md:border-0 '>Farmer: <span className='font-light'>--farmerName---</span> </div>
+                            </div>
+                        </div>
+
+                        <div className='py-1 flex flex-col xs:flex-row sm:justify-between'>
+                            <div className='flex justify-center xs:justify-none gap-x-3 xs:gap-x-3a sm:gap-x-5  '>
+                                <button 
+                                    className='
+                                        py-2 px-5 xs:px-6 sm:px-10 text-xs xs:text-sm font-medium border border-grey rounded
+                                        hover:bg-gray-100
+                                    '
+                                    onClick={() => navigate(`/order/track/${order.order_id}`)}
+                                >
+                                    Track Order
+                                </button>
+                                <button 
+                                    className='
+                                        py-2 px-5 xs:px-6 sm:px-10 text-xs xs:text-sm font-medium border border-grey rounded
+                                        hover:bg-gray-100
+                                    '
+                                    onClick={() => navigate(`/order/overview/${order.order_id}`)}
+                                >
+                                    Order Details
+                                </button>
+                            </div>
+
+                            <div className='flex justify-center mt-3 xs:mt-0  xs:px-3'>
+                                 <button 
+                                    className={`
+                                        py-2 px-8 sm:px-12 text-xs xs:text-sm font-medium  text-white rounded
+                                        ${order.order_status === 'pending' ? 'bg-red-600 hover:bg-red-700' : 'bg-red-900 opacity-80 cursor-not-allowed '}
+                                    `}
+                                    onClick={() => onCancelRequestedOrder(order.order_id)}
+                                    disabled={order.order_status !== 'pending'}
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+
+                    </div>
+                )) }
+            </div>
+
+        </div>
+    )
+}
+
+export default CustomerOrders

--- a/client/src/features/order/order.service.ts
+++ b/client/src/features/order/order.service.ts
@@ -70,15 +70,21 @@ export const orderApi = api.injectEndpoints({
             query: (farmerID: string) => `/order/farmer/${farmerID}`,
             providesTags: ['Order']
         }),
+        getOrdersByCustomerID: build.query<ResponseInterface, string>({
+            query: (customerID: string) => `/order/customer/${customerID}`,
+            providesTags: ['Order']
+        }),
     })
 })
 
 export const {
-   useCreateOrderMutation,
-   useAcceptOrderMutation,
-   useStartProccessMutation,
-   useStartDeliveryMutation,
-   useFinishOrderMutation,
-   useCancelOrderMutation,
-   useGetOrdersByFarmerIDQuery
+    useCreateOrderMutation,
+    useAcceptOrderMutation,
+    useStartProccessMutation,
+    useStartDeliveryMutation,
+    useFinishOrderMutation,
+    useCancelOrderMutation,
+    useGetOrdersByFarmerIDQuery,
+    useGetOrdersByCustomerIDQuery
+   
 } = orderApi;

--- a/client/src/features/shared/utils/utilsFunctions.tsx
+++ b/client/src/features/shared/utils/utilsFunctions.tsx
@@ -120,6 +120,48 @@ export const getOrderBackgroundColor = (uiStatus: string): string => {
     }
 };
 
+export const mapOrderCustomerStatusToUILabel = (status: string): string => {
+    switch (status) {
+        case 'pending':
+            return 'Requested';
+        case 'accepted':
+            return 'In progress';
+        case 'processing':
+            return 'In progress';
+        case 'shipped':
+            return 'In progress';
+        case 'completed':
+            return 'Delivered';
+        case 'canceled':
+            return 'Canceled';
+        case 'rejected':
+            return 'Canceled';
+        default:
+            return 'Unknown';
+    }
+}; 
+
+export const getCustomerOrderBackgroundColor = (uiStatus: string): string => {
+    switch (uiStatus) {
+        case 'pending':
+            return 'bg-gray-400';
+        case 'accepted':
+            return 'bg-yellow-400';
+        case 'processing':
+            return 'bg-yellow-400';
+        case 'shipped':
+            return 'bg-yellow-400';
+        case 'completed':
+            return 'bg-green-400';
+        case 'canceled':
+            return 'bg-red-400';
+        case 'rejected':
+            return 'bg-red-400';
+        default:
+            return 'bg-gray-400';
+    }
+};
+
 export const  formatOrderDate = (createdAt: string | Date): string => {
     const date = new Date(createdAt);
     const day = date.getDate();


### PR DESCRIPTION
### Summary
- Add  CustomerOrders UI component to dispay and manage orders fro the logged-in customer
- Integrated with getOrdersByCustomerID RTK Query endpoint in order.service.ts
- Updated utilsFunctions.tsx with mapping helpers for orders status label and background colors.


### Notes
- Sorting and infinity scroll( infinite loading) are not implemented yet (planned in a seperate PR)
- Farmer name field pending additional fetching from User service 
- Download invoice functionality is a placeholder (no PDF generation yet).
- Real-time updates (socketIO notification ) not implemented yet

### Checklist
- [x] Added CustomerOrders component with UI and integrations.
- [x] Integrated with getOrdersByCustomerID RTQ Query endpoint.
- [x] Created utility functions for status mapping and backgrouind colors
- [x] Cancel order mutation works and updates UI states.
- [ ] Sorting and infinite loading for orders.
- [ ] Download invoice feature.
- [ ] Real-time updates with Socket.IO notifications

