### PR TITLE
refactor: order and order_items: BE & FE interfaces, schema and placi…

### DIFF
--- a/client/src/features/order/order.interface.ts
+++ b/client/src/features/order/order.interface.ts
@@ -93,6 +93,9 @@ export interface OrderProductsListPropsInterface {
 //FOR API BODY REQUEST
 export interface OrderItemRequestInterface {
     product_id: string;
+    product_name: string;    
+    product_image_url: string;  
+    product_unit: string;
     quantity: number;
     unit_price: number;
     total_price: number;
@@ -102,18 +105,21 @@ export interface OrderRequestBodyInterface {
     customer_id: string;
     customer_username: string;
     customer_email: string;
+    customer_first_name?: string; // form field snapshot
+    customer_last_name?: string;  // form field snapshot
+    customer_phone?: string;      // form field snapshot
     farmer_id: string;
     farmer_username: string;
     farmer_email: string;
     invoice_id: string;
     total_price: number;
-    // payment_status?: 'pending';
     payment_status?: OrderPaymentStatusType;
     order_status: OrderStatusType;
     payment_type: 'cod' | 'stripe';
     payment_method_id?: string;
     billing_address?: string;
     shipping_address: string;
+    shipping_postal_code?: string;
     tracking_url?: string;
     orderItems: OrderItemRequestInterface[];
 }

--- a/server/microservices/gateway/package-lock.json
+++ b/server/microservices/gateway/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@elastic/elasticsearch": "^8.17.0",
         "@socket.io/redis-adapter": "^8.3.0",
-        "@veckovn/growvia-shared": "^1.1.9",
+        "@veckovn/growvia-shared": "^1.2.0",
         "axios": "^1.7.9",
         "compression": "^1.7.5",
         "cookie-session": "^2.1.0",
@@ -2484,9 +2484,9 @@
       }
     },
     "node_modules/@veckovn/growvia-shared": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@veckovn/growvia-shared/-/growvia-shared-1.1.9.tgz",
-      "integrity": "sha512-t7XfMUZ4P7Ywb5yLL5NKwXcj7eEZSHx1aZ/erPcWQSyjv3mEzs2dUAx/REPP+bUcysjEvNPacblWxglbk9uVOQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@veckovn/growvia-shared/-/growvia-shared-1.2.0.tgz",
+      "integrity": "sha512-J1j7WmjUrTL5JYOg56gsOFblBQ7b2/JNqahx4eaJTxsvLdojkY3plG3wuWAFcOSzyrG/QoXGz+1UYnoofCKYFQ==",
       "license": "MIT",
       "dependencies": {
         "cloudinary": "^2.6.0",

--- a/server/microservices/gateway/package.json
+++ b/server/microservices/gateway/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "^8.17.0",
     "@socket.io/redis-adapter": "^8.3.0",
-    "@veckovn/growvia-shared": "^1.1.9",
+    "@veckovn/growvia-shared": "^1.2.0",
     "axios": "^1.7.9",
     "compression": "^1.7.5",
     "cookie-session": "^2.1.0",

--- a/server/microservices/order/package-lock.json
+++ b/server/microservices/order/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.17.1",
-        "@veckovn/growvia-shared": "^1.1.9",
+        "@veckovn/growvia-shared": "^1.2.0",
         "amqplib": "^0.10.3",
         "cloudinary": "^2.5.1",
         "compression": "^1.8.0",
@@ -2191,9 +2191,9 @@
       }
     },
     "node_modules/@veckovn/growvia-shared": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@veckovn/growvia-shared/-/growvia-shared-1.1.9.tgz",
-      "integrity": "sha512-t7XfMUZ4P7Ywb5yLL5NKwXcj7eEZSHx1aZ/erPcWQSyjv3mEzs2dUAx/REPP+bUcysjEvNPacblWxglbk9uVOQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@veckovn/growvia-shared/-/growvia-shared-1.2.0.tgz",
+      "integrity": "sha512-J1j7WmjUrTL5JYOg56gsOFblBQ7b2/JNqahx4eaJTxsvLdojkY3plG3wuWAFcOSzyrG/QoXGz+1UYnoofCKYFQ==",
       "license": "MIT",
       "dependencies": {
         "cloudinary": "^2.6.0",

--- a/server/microservices/order/package.json
+++ b/server/microservices/order/package.json
@@ -20,7 +20,7 @@
   "description": "",
   "dependencies": {
     "@elastic/elasticsearch": "^8.17.1",
-    "@veckovn/growvia-shared": "^1.1.9",
+    "@veckovn/growvia-shared": "^1.2.0",
     "amqplib": "^0.10.3",
     "cloudinary": "^2.5.1",
     "compression": "^1.8.0",

--- a/server/microservices/order/src/postgreSQL.ts
+++ b/server/microservices/order/src/postgreSQL.ts
@@ -28,11 +28,14 @@ const orderTable = `
 
     CREATE TABLE IF NOT EXISTS public.orders (
         order_id UUID DEFAULT uuid_generate_v4(),  -- UUID for unique order ID
-        customer_id TEXT NOT NULL,  -- MongoDB ObjectId stored as TEXT (or VARCHAR)
-        customer_username TEXT, 
-        customer_email TEXT,
-        farmer_id TEXT NOT NULL,  -- MongoDB ObjectId stored as TEXT (or VARCHAR)
+        farmer_id TEXT NOT NULL,  -- Farmer ID from User Serivce
         farmer_username TEXT,
+        customer_id TEXT NOT NULL,  -- Customer id from User Service
+        customer_username TEXT, 
+        customer_email TEXT,  -- Form 'email' doesn't have to match User Service 'email'
+        customer_first_name TEXT,  -- Form 'customer_first_name' doesn't have to match User Service 'first_name'
+        customer_last_name TEXT, -- Form 'customer_last_name' doesn't have to match User Service 'last_name'
+        customer_phone TEXT,  -- Form 'customer_phone' doesn't have to match User Service 'phone'
         farmer_email TEXT,
         invoice_id TEXT,
         total_price DECIMAL(10, 2) NOT NULL,
@@ -42,7 +45,8 @@ const orderTable = `
         payment_method VARCHAR(225),
         payment_method_id VARCHAR(255),
         payment_type VARCHAR(50),
-        shipping_address TEXT,
+        shipping_address TEXT, -- Contian address and city together 'Address,City'
+        shipping_postal_code TEXT,
         billing_address TEXT,
         delivery_date TIMESTAMP,
         payment_expires_at TIMESTAMP,
@@ -56,7 +60,10 @@ const orderTable = `
     CREATE TABLE IF NOT EXISTS public.order_items (
         order_item_id UUID DEFAULT uuid_generate_v4(),  -- UUID for unique order item ID
         order_id UUID NOT NULL,  -- Foreign key to the order
-        product_id TEXT NOT NULL,  -- MongoDB ObjectId stored as TEXT (referencing the product)
+        product_id TEXT NOT NULL,  -- Product ID from Product Service
+        product_name TEXT NOT NULL, --Save for snapshot (at the time of order creation)
+        product_image_url TEXT NOT NULL, -- Save for snapshot (at the time of order creation)
+        product_unit TEXT NOT NULL, -- Save for snapshot
         quantity INT NOT NULL,  -- Number of products in the order
         unit_price DECIMAL(10, 2) NOT NULL,  -- Price of the product at the time of purchase
         total_price DECIMAL(10, 2) NOT NULL,  -- total price for this item (quantity * unit_price)

--- a/server/microservices/order/src/schema/order.schema.ts
+++ b/server/microservices/order/src/schema/order.schema.ts
@@ -13,6 +13,9 @@ const OrderCreateZodSchema = z.object({
             /^[a-zA-Z][a-zA-Z0-9_]*$/,
             "Username must start with a letter and can only contain letters, numbers, and underscores"
         ),
+    customer_first_name: z.string().max(50, "First name too long").optional(),
+    customer_last_name: z.string().max(50, "Last name too long").optional(),
+    customer_phone: z.string().max(20, "Phone number too long").optional(),
     farmer_email: z.string().min(1, "Farmer Email is required").email("Invalid email format"),
     farmer_username: z.string()
         .min(3, "Farmer Username too short")
@@ -45,6 +48,7 @@ const OrderCreateZodSchema = z.object({
     // payment_expires_at: z.date().optional(), 
     payment_expires_at: z.string().optional(), 
     shipping_address: z.string().max(100, "Address too long").optional(),
+    shipping_postal_code: z.string().max(20, "Postal code too long").optional(),
     billing_address: z.string().max(100, "Address too long").optional(),
     delivery_date: z.string().optional(),
     tracking_url: z.string().optional(),
@@ -59,6 +63,8 @@ const OrderUpdateZodSchema = OrderCreateZodSchema.partial();
 const OrderItemCreateZodSchema = z.object({
     order_id: z.string().uuid("Invalid order ID").min(1, "Order ID is required"),
     product_id: z.string().min(1, "Product ID is required"),
+    product_name: z.string().min(1, "Product name is required"),
+    product_image_url: z.string().url("Invalid product image URL"),
     quantity: z.number().min(1, "Quantity must be at least 1"),
     unit_price: z.number().min(0, "Unit price must be non-negative"),
     total_price: z.number().min(0, "Total price must be non-negative"),

--- a/server/microservices/order/src/services/order.ts
+++ b/server/microservices/order/src/services/order.ts
@@ -97,12 +97,15 @@ const placePendingOrder = async(orderData: OrderCreateInterface):Promise<OrderDo
         //2. Insert Order
         const orderInsertQuery = `
         INSERT INTO public.orders (
-            customer_id,
             farmer_id,
-            customer_email,
-            customer_username,
             farmer_email,
             farmer_username,
+            customer_id,
+            customer_email,
+            customer_username,
+            customer_first_name,
+            customer_last_name,
+            customer_phone,
             invoice_id,
             total_price, 
             order_status, 
@@ -112,22 +115,26 @@ const placePendingOrder = async(orderData: OrderCreateInterface):Promise<OrderDo
             payment_method_id,
             payment_method,
             payment_expires_at,
-            shipping_address, 
+            shipping_address,
+            shipping_postal_code, 
             billing_address, 
             delivery_date, 
             tracking_url
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) 
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23) 
         RETURNING order_id;
         `;
 
         const values = [
-            orderData.customer_id,
             orderData.farmer_id,
-            orderData.customer_email,
-            orderData.customer_username,
             orderData.farmer_email,
             orderData.farmer_username,
+            orderData.customer_id,
+            orderData.customer_email,
+            orderData.customer_username,
+            orderData.customer_first_name || null,
+            orderData.customer_last_name || null,
+            orderData.customer_phone || null,
             orderData.invoice_id || null,
             orderData.total_price,
             orderData.order_status || "pending", 
@@ -138,6 +145,7 @@ const placePendingOrder = async(orderData: OrderCreateInterface):Promise<OrderDo
             orderData.payment_method || null,
             orderData.payment_expires_at || null,
             orderData.shipping_address || null,
+            orderData.shipping_postal_code || null,
             orderData.billing_address || null,
             orderData.delivery_date || null,
             orderData.tracking_url || null
@@ -149,8 +157,17 @@ const placePendingOrder = async(orderData: OrderCreateInterface):Promise<OrderDo
 
         //3. Insert The Order Items  
         const orderItemInsertQuery = `
-            INSERT INTO order_items (order_id, product_id, quantity, unit_price, total_price)
-            VALUES ($1, $2, $3, $4, $5);
+            INSERT INTO order_items (
+                order_id,
+                product_id, 
+                product_name,
+                product_image_url,
+                product_unit,
+                quantity, 
+                unit_price, 
+                total_price
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
         `
 
         //loop through orderItems that passed as props of orderData
@@ -158,6 +175,9 @@ const placePendingOrder = async(orderData: OrderCreateInterface):Promise<OrderDo
             const orderItemValues = [
                 order_id, //same order id for each orderItem
                 item.product_id,
+                item.product_name,
+                item.product_image_url,
+                item.product_unit,
                 item.quantity,
                 item.unit_price,
                 item.total_price


### PR DESCRIPTION
### Summary
- Refactored orders and order_items functionality across BE and FE.
- Added support for product_unit in order items.
- Updated Gateway and Order Service shared library @veckovn/growvia-shared with new interfaces for order creation and snapshot data.
- Updated frontend order placement component and interfaces to match backend.


### Details

- REFACTORED DATA MODEL – Snapshot Design:
   - The Order Service now stores a snapshot of customer and product data at the time of order creation.
  - Customer snapshot fields (from order form, not directly from User Service): customer_first_name, customer_last_name, customer_phone, shipping_address, shipping_postal_code.
  - Product snapshot fields (from Product Service at checkout time): product_name, product_image_url, product_unit.
 
- Shared Library Updates:
  - Updated @veckovn/growvia-shared with OrderCreateInterface and OrderItemCreateInterface reflecting snapshot and product_unit.


### Notes
- Sorting and filtering features are **not implemented yet** (planned for a separate PR).

### Checklist
- [x] Backend Zod schemas updated and validated.
- [x] PostgreSQL tables updated (orders & order_items).
- [x] Transaction-safe insertion of orders and order items
- [x] Interfaces updated on both BE and FE, including shared library @veckovn/growvia-shared
- [x] Full order placement tested locally.
