### PR TITLE
refactor: restructure appRoutes with adding RequreCustomerOrGuestRotu…

### DIFF
--- a/client/src/AppRoutes.tsx
+++ b/client/src/AppRoutes.tsx
@@ -10,6 +10,8 @@ import ProductOverview from './features/product/components/ProductOverview';
 import FarmerOverview from './features/farmer/components/FarmerOverview';
 import FarmerOrders from './features/farmer/components/FarmerOrders';
 
+import RequireCustomerOrGuestRoute from './features/RequireCustomerOrGuestRoute';
+import RequireGuestRoute from './features/RequireGuestRoute';
 import RequireAuthRoute from './features/RequireAuthRoute';
 
 import SignIn from './features/auth/components/SignIn';
@@ -36,44 +38,96 @@ const AppRouter: FC = () => {
     const routes: RouteObject[] = [
         {
             path: '/',
-            element: <MainLayout> <Index/> </MainLayout>
+            element: (
+                <RequireCustomerOrGuestRoute>
+                    <MainLayout> 
+                        <Index/> 
+                    </MainLayout>
+                </RequireCustomerOrGuestRoute> 
+            )
         },
         {
             path: '/market',
-            element: <MainLayout> <Market/> </MainLayout>
+            element: (
+                <RequireCustomerOrGuestRoute>
+                    <MainLayout> 
+                        <Market/>  
+                    </MainLayout>
+                </RequireCustomerOrGuestRoute> 
+            )
         },
         {
             path: '/farmers',
-            element: <MainLayout> <Market/> </MainLayout>
+            element: (
+                <RequireCustomerOrGuestRoute>
+                    <MainLayout> 
+                        <Market/>  
+                    </MainLayout>
+                </RequireCustomerOrGuestRoute> 
+            )
         },
-
         {
             path: '/product/overview/:id',
-            element: <MainLayout> <ProductOverview /> </MainLayout>
+            element: (
+                <RequireCustomerOrGuestRoute>
+                    <MainLayout> 
+                        <ProductOverview />  
+                    </MainLayout>
+                </RequireCustomerOrGuestRoute> 
+            )
         },
-
         {
             path: '/farmer/overview/:id',
-            element: <MainLayout> <FarmerOverview /> </MainLayout>
+            element: (
+                <RequireCustomerOrGuestRoute>
+                    <MainLayout> 
+                        <FarmerOverview /> 
+                    </MainLayout>
+                </RequireCustomerOrGuestRoute> 
+            )
         },
 
         //Signup/SignIn 
         //Main Layout with different Header->AuthHeader
         {
             path: '/signup',
-            element: <MainLayout authPage={true}> <SignUp/> </MainLayout>
+            element: (
+                <RequireGuestRoute>
+                    <MainLayout authPage={true}> 
+                        <SignUp/> 
+                    </MainLayout>
+                </RequireGuestRoute>
+            )
         },
         {
             path: '/signin',
-            element: <MainLayout authPage={true}> <SignIn/> </MainLayout>
+            element: (
+                <RequireGuestRoute>
+                    <MainLayout authPage={true}> 
+                        <SignIn/>
+                    </MainLayout>
+                </RequireGuestRoute>
+            )
         },
         {
             path: '/forgot-password',
-            element: <MainLayout authPage={true}> <ForgotPassword/> </MainLayout>
+            element: (
+                <RequireGuestRoute>
+                    <MainLayout authPage={true}> 
+                        <ForgotPassword/>
+                    </MainLayout>
+                </RequireGuestRoute>
+            )
         },
         { //When user click on "change Password" on received mail
             path: '/reset-password',
-            element: <MainLayout authPage={true}> <ResetPassword/> </MainLayout>
+            element: (
+                <RequireGuestRoute>
+                    <MainLayout authPage={true}> 
+                        <ResetPassword/>
+                    </MainLayout>
+                </RequireGuestRoute>
+            )
         },
         
         //for logged users
@@ -161,7 +215,6 @@ const AppRouter: FC = () => {
                 {path:'settings', element: <Settings/>}, 
             ]
         }
-
     ]
 
     return useRoutes(routes);

--- a/client/src/features/RequireAuthRoute.tsx
+++ b/client/src/features/RequireAuthRoute.tsx
@@ -20,7 +20,6 @@ const RequireAuthRoute = ({
         }
     }, [error]);
 
-    // Show nothing while loading (or a loading spinner)
     if (isLoading) return null;
 
     const userRole = data?.user?.userType;
@@ -34,7 +33,9 @@ const RequireAuthRoute = ({
     // Handle unauthorized roles
     if (!allowedRoles.includes(userRole)) {
         toast.error("You don't have permission to access this resource");
-        return <Navigate to="/" replace />;
+        
+        if(userRole === 'farmer') return <Navigate to='/farmer' replace/>
+        if(userRole === 'customer') return <Navigate to='/' replace/>
     }
 
     return <>{children}</>

--- a/client/src/features/RequireCustomerOrGuestRoute.tsx
+++ b/client/src/features/RequireCustomerOrGuestRoute.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+import { useGetCurrentUserQuery } from "./auth/auth.service";
+import { Navigate } from "react-router-dom";
+
+const RequireCustomerOrGuestRoute = ({ children }: { children: ReactNode }) => {
+    const { data, isLoading } = useGetCurrentUserQuery();
+
+    if (isLoading) return null;
+
+    const userRole = data?.user?.userType;
+
+    if(userRole === 'farmer') return <Navigate to='/farmer' replace/>
+
+    return <>{children}</>
+};
+
+export default RequireCustomerOrGuestRoute;

--- a/client/src/features/RequireGuestRoute.tsx
+++ b/client/src/features/RequireGuestRoute.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+import { useGetCurrentUserQuery } from "./auth/auth.service";
+import { Navigate } from "react-router-dom";
+
+const RequireGuestRoute = ({ children }: { children: ReactNode }) => {
+    const { data, isLoading } = useGetCurrentUserQuery();
+
+    if (isLoading) return null;
+    
+    const userRole = data?.user?.userType;
+
+    if(userRole === 'farmer') return <Navigate to='/farmer' replace/>
+    if(userRole === 'customer') return <Navigate to='/' replace/>
+
+    return <>{children}</>
+};
+
+export default RequireGuestRoute;


### PR DESCRIPTION
### Description
- Added RequireGuestRoute route gurad to allow routes only for guests (not logged users) -
   - routes like: signin, signup, forgotPassword, restartPassword 
- Added RequireCustomerOrGuestRoute route guard to allow routes for guest a
   - public routes like: homepage(landingPage), market, product/overview, faremr/overview
- updated App.routes.tsx to use the new guards for better separation of concerns  

### Notes 
- These are the same changes that were accidentally merged into main.

### Checklist
- [x] Verified redirection logic:
  - Logged-in Farmers -> /farmer
  - Logged-in Customer -> /
  - Guests -> allowed on guest routes and landing page on '/'
- [x] Tested manually for each type of user
