### PR TITLE
refactor: extract logout logic into userLogout custom hook and update…

### DIFF
--- a/client/src/features/auth/auth.service.ts
+++ b/client/src/features/auth/auth.service.ts
@@ -31,6 +31,8 @@ const authApi = api.injectEndpoints({ //in api(createApi) we'we created endpoint
             },
             invalidatesTags: ['Auth']
         }),
+        // Manually clear cache -Needed because RequireGuestRoute calls getCurrentUser. 
+        // Without clearing cache, it would return the old user after logout.
         logout: build.mutation<ResponseInterface, void>({
             query() {
                 return {
@@ -38,7 +40,17 @@ const authApi = api.injectEndpoints({ //in api(createApi) we'we created endpoint
                     method: 'POST'
                 };
             },
-            invalidatesTags: ['Auth']
+            async onQueryStarted(_, { dispatch, queryFulfilled }) {
+                try {
+                    await queryFulfilled;
+                    // Remove cached current user immediately after logout
+                    dispatch(
+                        api.util.resetApiState()
+                    );
+                } catch {
+                    // ignore errors
+                }
+            },
         }),
         forgotPassword: build.mutation<ResponseInterface, string>({
             query(email) {

--- a/client/src/features/shared/headers/Header.tsx
+++ b/client/src/features/shared/headers/Header.tsx
@@ -59,6 +59,10 @@ const Header: FC = (): ReactElement => {
         setIsCartOpen(!isCartOpen);        
     }
 
+    const closeProfileDropdown = ():void =>{
+        setIsProfileOpen(false);
+    }
+
     const onCloseCartDropdown = ():void => {
         setIsCartOpen(false);
     }
@@ -152,7 +156,7 @@ const Header: FC = (): ReactElement => {
 
                         {isProfileOpen &&
                             <div ref={profileDropdownRef} className='absolute top-10'>
-                                <ProfileDropdown authUser={authUser} />
+                                <ProfileDropdown authUser={authUser} closeProfileDropdown={closeProfileDropdown}/>
                             </div>
                         }
 

--- a/client/src/features/shared/headers/ProfileDropdown.tsx
+++ b/client/src/features/shared/headers/ProfileDropdown.tsx
@@ -1,31 +1,11 @@
 import { FC } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { ProfileDropdownProps } from '../interfaces';
-import { useDispatch } from 'react-redux';
-import { useLogoutMutation } from '../../auth/auth.service';
-import { removeUserFromSessionStorage } from '../utils/utilsFunctions';
-import { clearAuth } from '../../auth/auth.reducers';
-import { clearNotifications } from '../../notifications/notifications.reducers';
-import { toast } from 'react-hot-toast';
+
+import useLogout from '../hooks/useLogout';
 
 const ProfileDropdown: FC<ProfileDropdownProps> = ({ authUser, closeProfileDropdown }) => {
-    const navigate = useNavigate();
-    const dispatch = useDispatch();
-    const [logout] = useLogoutMutation();
-
-    const logoutHanlder = async (): Promise<void> => {
-        try {
-            await logout();
-            dispatch(clearAuth());
-            dispatch(clearNotifications());
-            removeUserFromSessionStorage();
-            toast.success("You're logged out");
-            navigate('/signin');
-        }
-        catch (error) {
-            console.log("Logout error:");
-        }
-    }
+    const logoutHandler = useLogout()
 
     return (
         <div className='bg-white border border-greyB rounded-xl'>
@@ -40,29 +20,29 @@ const ProfileDropdown: FC<ProfileDropdownProps> = ({ authUser, closeProfileDropd
 
                 { authUser.userType === 'farmer' ?
                 <>
-                    <li className='w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200'>
+                    <li className="w-full">
                         <Link
-                            //customer/account or farmer/customer 
-                            to={`/farmer `}
+                            className="block w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200"
+                            to="/farmer"
                             onClick={closeProfileDropdown}
                         >
                             Dashboard
                         </Link>
                     </li>
 
-                    <li className='w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200'>
+                    <li className="w-full">
                         <Link
-                            //customer/account or farmer/customer 
-                            to={`/farmer/profile`}
+                            to="/farmer/profile"
                             onClick={closeProfileDropdown}
+                            className="block w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200"
                         >
                             Profile
                         </Link>
                     </li>
 
-                    <li className='w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200'>
+                    <li className='w-full '>
                         <Link
-                            //customer/account or farmer/customer 
+                            className="block w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200" 
                             to={`/farmer/products`}
                             onClick={closeProfileDropdown}
                         >
@@ -70,21 +50,26 @@ const ProfileDropdown: FC<ProfileDropdownProps> = ({ authUser, closeProfileDropd
                         </Link>
                     </li>
 
-                    <li className='w-full p-2 px-3 disabled text-gray-300'>
+                    {/* <li className='w-full'>
                         <Link
-                            //customer/account or farmer/customer 
-                            to={`/farmer/products `}
+                            className="block w-full p-2 px-3 text-gray-300 cursor-default transition-colors duration-200" 
+                            to={`/farmer/iot `}
                             onClick={closeProfileDropdown}
                         >
                             Iot Management
                         </Link>
+                    </li> */}
+                    <li className="w-full">
+                        <span className="block w-full p-2 px-3 text-gray-300 cursor-default transition-colors duration-200">
+                            IoT Management
+                        </span>
                     </li>
                 </>
                 :
                 //not farmer -> its customer
-                <li className='w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200'>
+                <li className='w-full'>
                     <Link
-                        //customer/account or farmer/customer 
+                        className="block w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200" 
                         to={`/${authUser.userType}/profile `}
                         onClick={closeProfileDropdown}
                     >
@@ -94,8 +79,9 @@ const ProfileDropdown: FC<ProfileDropdownProps> = ({ authUser, closeProfileDropd
 
                 }
                 
-                <li className='p-2 px-3 hover:bg-gray-100 transition-colors duration-200'>
+                <li className='w-full'>
                     <Link
+                        className="block w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200" 
                         to={`/${authUser.userType}/orders `}
                         onClick={closeProfileDropdown}
                     >
@@ -103,8 +89,9 @@ const ProfileDropdown: FC<ProfileDropdownProps> = ({ authUser, closeProfileDropd
                     </Link>
                 </li>
 
-                <li className='p-2 px-3 hover:bg-gray-100 transition-colors duration-200'>
+                <li className='w-full'>
                     <Link
+                        className="block w-full p-2 px-3 hover:bg-gray-100 transition-colors duration-200" 
                         to={`/${authUser.userType}/settings `}
                         onClick={closeProfileDropdown}
                     > 
@@ -115,7 +102,7 @@ const ProfileDropdown: FC<ProfileDropdownProps> = ({ authUser, closeProfileDropd
 
             <div
                 className='p-2 px-3 rounded-b-xl hover:bg-gray-100 transition-colors duration-200 cursor-pointer'
-                onClick={logoutHanlder}
+                onClick={logoutHandler}
             >
                 Logout
             </div>

--- a/client/src/features/shared/hooks/useLogout.tsx
+++ b/client/src/features/shared/hooks/useLogout.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+import { useAppDispatch } from "../../../store/store";
+import { useLogoutMutation } from "../../auth/auth.service";
+import { removeUserFromSessionStorage } from "../utils/utilsFunctions";
+import { clearAuth } from "../../auth/auth.reducers";
+import { clearNotifications } from "../../notifications/notifications.reducers";
+import { toast } from 'react-hot-toast';
+
+const useLogout = () => {
+    const navigate = useNavigate();
+    const dispatch = useAppDispatch();
+    const [logout] = useLogoutMutation();
+
+    const logoutHanlder = async():Promise<void> => {
+        try{
+            await logout();
+            dispatch(clearAuth());
+            dispatch(clearNotifications());
+            removeUserFromSessionStorage();
+            toast.success("You're logged out");
+            navigate('/signin');
+        }
+        catch(error){
+            console.error("Logout error: ", error);
+            toast.error("Logout failed. Please try again.");
+        }
+    }
+
+    return logoutHanlder;
+}
+
+export default useLogout;

--- a/client/src/features/shared/sideNavBars/FarmerSideNavbar.tsx
+++ b/client/src/features/shared/sideNavBars/FarmerSideNavbar.tsx
@@ -1,10 +1,11 @@
-import { FC , memo} from 'react';
+import { FC, memo } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAppSelector } from '../../../store/store';
 import { ReduxStateInterface } from '../../../store/store.interface';
-import useNotificationsDropdown from '../hooks/useNotificationsDropdown';
 import HeaderIconBadge from '../headers/HeaderIconBadge';
 import NotificationsDropdown from '../../notifications/components/NotificationsDropdown';
+import useNotificationsDropdown from '../hooks/useNotificationsDropdown';
+import useLogout from '../hooks/useLogout';
 
 import LogoIcon from '../../../assets/header/LogoIcon.svg';
 import Bell from '../../../assets/header/Bell.svg'
@@ -14,14 +15,16 @@ import ProductIcon from '../../../assets/navBar/Products.svg';
 import OrdersIcon from '../../../assets/navBar/Orders.svg';
 import SettingsIcon from '../../../assets/navBar/Settings.svg';
 import LockerIcon from '../../../assets/navBar/Locker.svg';
+import LogutIcon from '../../../assets/navBar/Logout.svg';
 
 const FarmerSideNavbar:FC = memo(() => {
     const notifications = useAppSelector((state: ReduxStateInterface) => state.notifications);
     const { notificationsDropwdownRef, isNotificationsOpen, toggleNotificationsDropdown} = useNotificationsDropdown();
+    const logoutHandler = useLogout();
 
     return (
         <nav className='w-[270px] bg-white'>
-
+            
             <div className='flex items-center py-4 relative'>
                 {isNotificationsOpen &&
                     <div ref={notificationsDropwdownRef} className='w-full absolute top-14 left-[100px] z-10'>
@@ -160,11 +163,14 @@ const FarmerSideNavbar:FC = memo(() => {
                     </NavLink>
                 </li>
 
-               <li className='w-full mt-10 cursor-pointer'>
+               <li 
+                    className='w-full mt-10 cursor-pointer' 
+                    onClick={logoutHandler}
+                >
                     <div className='flex items-center w-full h-12 p-2 px-4 hover:bg-green2 transition-colors duration-200'>
                         <img
                             className='w-4 h-4 '
-                            src={HomeIcon}
+                            src={LogutIcon}
                             alt='logo'
                         />
                         <div className='relative w-full flex items-center text-green10 pl-2 '> SignOut </div>


### PR DESCRIPTION
### Description
- Extract logout logic into a reusable useLogout custom hook.
- Updated multiple components (ProfileDropdown, FarmerSideNavbar) to use useLogout hook.
- Added onQueryStarted in RTK Query logout mutation
   - This ensures that after logout, cached data is cleared from RTK Query.
- Simplified navigation and dispatch calls

###Detaisl
- Without removing cached data from RTK Query if a user navigates to pages like Signup or other pages checking for the logged-in user, stale cached data could make it seem like the user is still logged in.

### Checklist
- [x] Logout works correctly and redirects to '/singup/ page.
- [x] RTK Query cached  data  is cleared after logout.