### PR TITLE
feat: add farmers serach API with pagination and total count

### DIFF
--- a/server/microservices/gateway/src/controllers/users/farmer.ts
+++ b/server/microservices/gateway/src/controllers/users/farmer.ts
@@ -3,6 +3,7 @@ import {
     getFarmerDetailsByID,
     getFarmerDetailsByUsername,
     getFarmerDetailsByEmail,
+    getSerachFarmers,
     getNewestFarmers,
     updateFarmerData
 } from "@gateway/services/user.service";
@@ -23,6 +24,20 @@ export async function getByEmail(req:Request, res:Response):Promise<void>{
     const response: AxiosResponse = await getFarmerDetailsByEmail(req.params.email); 
     res.status(200).json({ message:response.data.message, user:response.data.user});
 }
+
+export async function serachFarmers(req:Request, res:Response):Promise<void>{
+    const from = parseInt(req.query.from as string) || 0;
+    const size = parseInt(req.query.size as string) || 12;
+    const farmerQuery = (req.query.farmerQuery as string) || '';
+
+    const response: AxiosResponse = await getSerachFarmers({from, size, farmerQuery});
+    res.status(200).json({ 
+        message:response.data.message, 
+        farmers:response.data.farmers, 
+        total:response.data.total
+    });
+}
+
 export async function newestFarmers(req:Request, res:Response):Promise<void>{
     const limit = parseInt(req.params.limit);
     const response: AxiosResponse = await getNewestFarmers(limit); 

--- a/server/microservices/gateway/src/routes/users/farmerPublic.ts
+++ b/server/microservices/gateway/src/routes/users/farmerPublic.ts
@@ -1,10 +1,11 @@
 import express, { Router } from 'express';
-import { getByID, newestFarmers } from '@gateway/controllers/users/farmer';
+import { getByID, newestFarmers, serachFarmers } from '@gateway/controllers/users/farmer';
 
 const router: Router = express.Router();
 
 const farmerPublicRoutes = (): Router => {
     //api/gatewy/v1/users/farmer/id/:ID
+    router.get('/users/farmer/search', serachFarmers)
     router.get('/users/farmer/id/:ID', getByID); //put in private
     router.get('/users/farmer/newest/:limit', newestFarmers)
     return router;

--- a/server/microservices/gateway/src/services/user.service.ts
+++ b/server/microservices/gateway/src/services/user.service.ts
@@ -1,7 +1,7 @@
 import { createAxiosInstance } from "@gateway/axios";
 import { config } from '@gateway/config';
 import { AxiosResponse } from "axios";
-import { CustomerDocumentInterface, FarmerDocumentInterface } from "@veckovn/growvia-shared"
+import { CustomerDocumentInterface, FarmerDocumentInterface, FarmerSearchOptionsInterface } from "@veckovn/growvia-shared"
 
 const usersAxiosInstance = createAxiosInstance(`${config.USER_SERVICE_URL}/api/v1/users`, 'user');
 
@@ -64,6 +64,12 @@ async function getFarmerDetailsByEmail(email: string):Promise<AxiosResponse> {
     return res;
 }
 
+async function getSerachFarmers(params: FarmerSearchOptionsInterface ):Promise<AxiosResponse> {
+    const res: AxiosResponse = await usersAxiosInstance.get('/farmer/search', { params });
+    return res;
+}
+
+
 async function getNewestFarmers(limit: number):Promise<AxiosResponse> {
     const res: AxiosResponse = await usersAxiosInstance.get(`/farmer/newest/${limit}`);
     return res;
@@ -88,6 +94,7 @@ export {
     getFarmerDetailsByID,
     getFarmerDetailsByUsername,
     getFarmerDetailsByEmail,
+    getSerachFarmers,
     getNewestFarmers,
     updateFarmerData
 }

--- a/server/microservices/users/src/controllers/farmer.ts
+++ b/server/microservices/users/src/controllers/farmer.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express"
 import { FarmerDocumentInterface } from "@veckovn/growvia-shared";
-import { getFarmerByID ,getFarmerByUsername, getFarmerByEmail, getNewest, updateFarmerDataByID } from "@users/services/farmer";
+import { getFarmerByID ,getFarmerByUsername, getFarmerByEmail, searchFarmers, getNewest, updateFarmerDataByID } from "@users/services/farmer";
 
 const getFarmerDetailsByID = async (req:Request, res:Response):Promise<void> => {
     const ID = req.params.ID;
@@ -20,9 +20,17 @@ const getFarmerDetailsByEmail = async (req:Request, res:Response):Promise<void> 
     res.status(200).json({message: "Farmer Profile Data By email", user: farmerData});
 }
 
+const getFarmersBySearch = async (req:Request, res:Response):Promise<void> => {
+    const from = parseInt(req.query.from as string) || 0;
+    const size = parseInt(req.query.size as string) || 12;
+    const farmerQuery = (req.query.farmerQuery as string) || '';
+
+    const {farmers, total } = await searchFarmers(from, size, farmerQuery);
+    res.status(200).json({message: "Serach Farmers", farmers: farmers, total});
+}
+
 const getNewestFarmers = async (req:Request, res:Response):Promise<void> => {
     const limit = parseInt(req.params.limit);
-    console.log("SHJA", limit);
     const farmers:FarmerDocumentInterface[] = await getNewest(limit);
     res.status(200).json({message: "Newest Farmers Data", farmers: farmers});
 }
@@ -38,6 +46,7 @@ export{
     getFarmerDetailsByID,
     getFarmerDetailsByUsername,
     getFarmerDetailsByEmail,
+    getFarmersBySearch,
     getNewestFarmers,
     updateFarmerData
 }

--- a/server/microservices/users/src/routes/farmer.ts
+++ b/server/microservices/users/src/routes/farmer.ts
@@ -3,6 +3,7 @@ import {
     getFarmerDetailsByID,
     getFarmerDetailsByUsername,
     getFarmerDetailsByEmail,
+    getFarmersBySearch,
     getNewestFarmers,
     updateFarmerData
 } from "@users/controllers/farmer"
@@ -14,6 +15,7 @@ export function farmerRoutes():Router {
     router.get('/username/:username', getFarmerDetailsByUsername);
     router.get('/email/:email', getFarmerDetailsByEmail);
     router.get('/newest/:limit', getNewestFarmers);
+    router.get('/search', getFarmersBySearch);
     router.patch('/id/:farmerID', updateFarmerData);
     return router;
 }

--- a/server/microservices/users/src/services/farmer.ts
+++ b/server/microservices/users/src/services/farmer.ts
@@ -39,6 +39,37 @@ const getFarmerByEmail = async(email: string): Promise<FarmerDocumentInterface |
     return farmerUser;
 }
 
+const searchFarmers = async(
+    from: number, 
+    size:number, 
+    farmerQuery:string
+// ): Promise<FarmerDocumentInterface[]> =>{
+): Promise<{farmers:FarmerDocumentInterface[], total:number}> =>{
+    const query: any = {}
+
+    if(farmerQuery || farmerQuery.trim() !==""){
+        query.farmName = { $regex: `^${farmerQuery.trim()}`, $options: "i" };
+    }
+
+    const [farmers, total] = await Promise.all([
+        FarmerModel.find(query)
+        .skip(from || 0)
+        .limit(size || 12)
+        .sort({ createdAt: -1 })
+        .exec(),
+
+        FarmerModel.countDocuments(query)
+    ])
+
+    // const farmers: FarmerDocumentInterface[] = await FarmerModel.find(query)
+    //     .skip(from || 0)
+    //     .limit(size || 12)
+    //     .sort({ createdAt: -1 })
+    //     .exec();
+
+    return {farmers, total};
+}
+
 const getNewest = async(limit: number = 10): Promise<FarmerDocumentInterface[]> =>{
     const newestFarmers: FarmerDocumentInterface[] = await FarmerModel
         .find()
@@ -114,6 +145,7 @@ export {
     getFarmerByID,
     getFarmerByUsername,
     getFarmerByEmail,
+    searchFarmers,
     getNewest,
     updateFarmerDataByID,
 }


### PR DESCRIPTION
### Description
- Implemented farmer search in UserService:
    - Added `GET /farmers/search` endpoint
    - Created `searchFarmers` service with regex filtering on farmName
    - Supports pagination (from, size) and returns total count
- Integrated search endpoint in Gateway service

### Checklist
- [x] Tested with and without farmerQuery
- [x] Returns correct total count
- [x] Verified Gateway forwards request/response correctly