### PR TITLE
RefactorL split FarmerProfile + feat: profile images upload

### DIFF
--- a/client/src/features/farmer/components/FarmerProfile.tsx
+++ b/client/src/features/farmer/components/FarmerProfile.tsx
@@ -1,261 +1,119 @@
-import { ChangeEvent, useState, useRef } from 'react';
-import TextField from "../../shared/inputs/TextField";
-import SelectField from '../../shared/inputs/SelectField';
+import { ChangeEvent } from 'react';
+import { useAppSelector } from '../../../store/store';
 import SocialLinks from '../../shared/user/SocialLinks';
 import toast from 'react-hot-toast';
-import { FarmerLocationInterface, LocationInterface } from '../../auth/auth.interfaces';
-import { FarmerProfileInterface } from '../farmer.interface';
-import { farmerProfileSchema } from '../farmer.schema';
-import { updateAuthUser } from '../../auth/auth.reducers';
 import { ReduxStateInterface } from '../../../store/store.interface';
-import { useAppSelector } from '../../../store/store';
-import { useAppDispatch } from '../../../store/store';
-import { useSchemaValidation } from '../../shared/hooks/useSchemaValidation';
-import { useUpdateFarmerMutation } from '../farmer.service';
-import { CITIES, SOCIAL } from '../../shared/utils/data';
-import { readAsBase64 } from '../../shared/utils/utilsFunctions';
+import LoadingSpinner from '../../shared/page/LoadingSpinner';
 
+import useFarmerProfile from '../../hooks/useFarmerProfile';
+import useProfileImages from '../../hooks/useProfileImages';
+import useProfileHeaderImages from '../../hooks/useProfileHeaderImages';
 
-import { PiPencil } from "react-icons/pi";
+import ProfileHeader from './ProfileHeader';
+import InfoForm from './InfoForm';
+import ProfileImages from './ProfileImages';
 
 const FarmerProfile = () => {
     const authUser = useAppSelector((state: ReduxStateInterface) => state.authUser)
-    const dispatch = useAppDispatch();
-    const backgroundInputRef = useRef<HTMLInputElement>(null);
-    const avatarInputRef = useRef<HTMLInputElement>(null);
 
-    const [ updateFarmer ] = useUpdateFarmerMutation();
+    const {
+        userData, 
+        setUserData,
+        uploadLoading,
+        validationErrors,
+        handleSubmit,
+        handleChange,
+        getBorderErrorStyle
+    } = useFarmerProfile(authUser);
 
-    const [userData, setUserData] = useState<FarmerProfileInterface>({
-        farmName: authUser.farmName,
-        firstName: authUser.fullName.split(' ')[0],
-        lastName: authUser.fullName.split(' ')[1],
-        phoneNumber: authUser.phoneNumber,
-        location: {
-            longitude:'',
-            latitude:'',
-            country:authUser.location.country,
-            city:authUser.location.city,
-            address:authUser.location.address,
-        }, 
-        profileAvatarFile: '',
-        backgroundImageFile: '', 
-        description: authUser.description, 
+    const {
+        backgroundInputRef,
+        avatarInputRef,
+        selectedImages,
+        handleImageFileChange,
+        handleRemoveImage
+    } = useProfileHeaderImages();
+    
+    const {
+        profileImages, 
+        existingProfileImages,
+        removedImages,
+        handleProfileImagesChange,
+        handleRemovePreviewProfileImage,
+        handleRemoveExistingProfileImage
+    } = useProfileImages(authUser);
 
-        //from backend we got socialLinks as string array
-        socialLinks: SOCIAL.map((el) => {
-            const existingUrl = authUser.socialLinks?.find((url: string) =>
-                url.toLowerCase().includes(el.name.toLowerCase())
-            );
-
-            return {
-                name: el.name,
-                url: existingUrl || '',
-            };
-        }),
-    });
-
-    const [selectedImages, setSelectedImages] = useState({
-        avatar: {
-            file: null as File | null,
-            preview: null as string | null
-        },
-        background: {
-            file: null as File | null,
-            preview: null as string | null
-        }
-    });
 
     const avatarSrc = selectedImages.avatar.preview || authUser.profileAvatar?.url || '';
     const backgroundSrc = selectedImages.background.preview || authUser.backgroundImage?.url || '';
 
-    const [actionError, setActionError] = useState<string>('');
-
-    const [schemaValidation, validationErrors, resetValidationErrors] = useSchemaValidation({
-        schema: farmerProfileSchema, 
-        userData
-    });
-
-    const getFieldError = (fieldName: string) => validationErrors[fieldName];
-
-    const getBorderErrorStyle = (field: string): string =>{
-        if(actionError || getFieldError(field))
-            return 'border-0 border-b-4 border-red-400';
-        else
-            return '';
-    }
-
-    const getChangedFields = (original: any, updated: any) => {
-        const changes: any = {};
-
-        const { firstName, lastName, ...updatedData } = updated;
-
-        const mergedData = {
-            ...updatedData,
-            fullName: `${firstName} ${lastName}`
-        };
-
-        for (const key in mergedData) {
-
-            if (key === 'location') {
-                const locationChanges: any = {};
-                const updatedLocation = mergedData.location || {};
-                const originalLocation = original?.location || {};
-
-                for (const locKey in updatedLocation) {
-                    // Only include if field exists in original OR the updated value is not empty
-                    const updatedVal = updatedLocation[locKey];
-                    const originalVal = originalLocation[locKey];
-
-                    if ( updatedVal !== originalVal && (originalVal !== undefined || updatedVal !== '')) {
-                        locationChanges[locKey] = updatedVal;
-                    }
-                }
-
-                if (Object.keys(locationChanges).length > 0) {
-                    changes.location = locationChanges;
-                }
-            }
-
-            else if (key === 'socialLinks') {
-                const originalLinks = original[key] || [];
-                const updatedLinks = mergedData[key] || [];
-
-                const bothEmpty = originalLinks.length === 0 && updatedLinks.length === 0;
-
-                if (!bothEmpty && JSON.stringify(originalLinks) !== JSON.stringify(updatedLinks)) {
-                    changes[key] = updatedLinks;
-                }
-            }
-
-            else if (key === 'profileAvatarFile' || key === 'backgroundImageFile') {
-                // Only include if actually set
-                if (mergedData[key] && mergedData[key] !== '') {
-                    changes[key] = mergedData[key];
-                }
-            }
-
-            else {
-                if (mergedData[key] !== original?.[key]) {
-                    changes[key] = mergedData[key];
-                }
-            }
-        }
-        return changes;
-    };
-
-    console.log("val Error:", validationErrors);
-    //dealing with partial updates (e.g., PATCH instead of PUT)
-    const onSubmitHandler = async():Promise<void> =>{
-
-        const isValid = await schemaValidation(); 
-
-        if(!isValid){
-            toast.error("Validation Field error");
-            return;
-        }
-
-        //transform socialLinks objects to string array
-        const social = userData.socialLinks
-            ?.filter((link) => link.url.trim() !== '')
-            .map((link) => link.url)
-
-        // const changes = getChangedFields(authUser, userData);
-        const newData = getChangedFields(authUser, {...userData, socialLinks:social});
-        console.log("Changes DaTA: ", newData);
-
-        if(Object.keys(newData).length === 0 ){
-            console.log("NO changed Data");
-            return;
-        }
-
+    const onSubmitHandler = async () => {
+        const additionalData = { removedImages }
         try{
-            if(!authUser.id){
-                console.log("Farmer user doesn't exist -> not authenicated")
-                return
-            }
-            const farmerID = authUser.id.toString();
-            const result = await updateFarmer({farmerID, updateData:newData})
-            console.log("update product result: ", result);
-
-            dispatch(updateAuthUser(newData));
-            toast.success("Successfully updated Profile")
-        }   
+            //passed aditional components (from other parts)
+            await handleSubmit(additionalData);
+            // await handleSubmit({removedImages});
+        }
         catch(error){
-            console.log("Error update Farmer: ", error);
-        }
-
+            console.log("onSubmitHandler ERROR: ", error);
+            toast.error(error); //caught from trown new Error in useFarmerProfile hook
+        } 
     }
 
-    const handleChange = (
-        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
-    ): void => {
-        const { name, value } = e.target;
-
-        //handling location object with {city and address prop}
-        if(name.startsWith("location.")) { 
-            //example for city -> name:location.city
-            const locationField = name.split('.')[1];//is 'city value'
-            setUserData(prev => ({
-                ...prev,
-                location: {
-                    ...prev.location,
-                    [locationField]: value
-                } as FarmerLocationInterface
-            }));
-        }
-        else { 
-            setUserData(prev => ({
-                ...prev,
-                [name]: value
-            }));
-        }
-    };
-
-
-    const handleImageFileChange = async ( e: ChangeEvent<HTMLInputElement>): Promise<void> => {
-        const file = e.target.files?.[0];
-        const name = e.target.name;
-        if(!file) return;
-
-        const preview = URL.createObjectURL(file);
-        setSelectedImages(prev => ({
-            ...prev,
-            [name === 'profileAvatarFile' ? 'avatar' : 'background']: {
-                file,
-                preview
-            }
-        }));
-
-        try{
-            const base64 = await readAsBase64(file);
-            setUserData(prev => ({
-                ...prev,
-                [name]: base64,
-            }));
+    const onImageFileChange = async (e: ChangeEvent<HTMLInputElement>): Promise<void> => {
+        try{ 
+            //anonymous callback func approach
+            handleImageFileChange(e, (name, base64) => {
+                setUserData(prev => ({
+                    ...prev,
+                    [name]: base64,
+                }));
+            })
         }
         catch(error){
             console.error("Faild to process avatar file:", error);
         }
     }
 
-    const handleRemoveImage = (type: 'avatar' | 'background') => {
-        // Clean up object URL
-        if (selectedImages[type].preview) {
-            URL.revokeObjectURL(selectedImages[type].preview!);
+    const onRemoveImage = (type: 'avatar' | 'background') => {
+        handleRemoveImage(type, () => {
+            setUserData(prev => ({
+                ...prev,
+                [type === 'avatar' ? 'profileAvatarFile' : 'backgroundImageFile']: ''
+            }));
+        });
+    };
+
+    const onProfileImagesChange = async (e:ChangeEvent<HTMLInputElement>, ) :Promise<void> => {
+        try{
+            //defined callback 
+             const updateProfileImages = (base64Files: string[]): void => {
+                setUserData((prev) => ({
+                    ...prev,
+                    profileImagesFile: [
+                    ...(prev.profileImagesFile || []),
+                    ...base64Files,
+                    ],
+                }));
+            };
+
+            //base64Files will be got when is updateFun(passed) called with hanl;deProfileImagesChange
+            await handleProfileImagesChange(e, updateProfileImages);
         }
+        catch(error){
+            console.log("Error handling profile images", error);
+        }   
+    }
 
-        // Reset to default
-        setSelectedImages(prev => ({
+    const onRemovePreviewProfileImage = (index: number): void => {
+        const updateUserData = (removeIndex: number) => {
+            setUserData((prev) => ({
             ...prev,
-            [type]: { file: null, preview: null }
-        }));
+            profileImagesFile: prev.profileImagesFile?.filter((_, i) => i !== removeIndex) || [],
+            }));
+        };
 
-        // Clear from form data
-        setUserData(prev => ({
-            ...prev,
-            [type === 'avatar' ? 'profileAvatarFile' : 'backgroundImageFile']: ''
-        }));
+        handleRemovePreviewProfileImage(index, updateUserData);
     };
 
     const handleSocialChange = (index: number, value: string) => {
@@ -269,359 +127,62 @@ const FarmerProfile = () => {
                 ...prev,
                 socialLinks: updatedLinks,
             };
-    });
+        });
     }
-
     
     return (
     <div className="mt-0 space-y-6">
         <h3 className='text-xl ml-3 font-medium'>
             Profile
         </h3>
-        <div 
-            className='relative w-full h-56 bg-cover bg-center overflow-hidden rounded '
-            // style={{ backgroundImage: `url(${authUser.backgroundImage?.url})`}}
-            style={{ backgroundImage: `url(${backgroundSrc})`}}
-        >
-            {/* Hidden file input and attached to the pencil icon*/}
-            {/* ofc this can be done with a "label" instead of ref */}
-            <input
-                type="file"
-                accept="image/*"
-                id="background-upload"
-                name="backgroundImageFile"
-                ref={backgroundInputRef}
-                onChange={handleImageFileChange}
-                className="hidden"
-            />
-            <button 
-                className='absolute left-2 bottom-2 p-1 bg-grey rounded cursor-pointer hover:bg-gray-300 group'
-                // onClick={onEditProfileAvatar}
-                onClick={() => backgroundInputRef.current?.click()}
-            >
-                <PiPencil className='text-2xl text-gray-600 group-hover:text-gray-800'/>
-            </button>
-
-            {/* Remove Button (only shows when new background is selected) */}
-            {selectedImages.background.preview && (
-            <div className='absolute top-2 right-2 w-8 h-8 group'>
-                <button
-                    // className='w-full h-full cursor-pointer  '
-                    className="w-full h-full cursor-pointer bg-red-500 group-hover:bg-red-600 rounded-full flex justify-center items-center"
-                    onClick={() => handleRemoveImage('background')}
-                >
-                    {/* <div className="w-full h-full text-white font-bold text-sm flex justify-center items-center bg-red-500 rounded-full border group-hover:bg-red-600">X</div> */}
-                    <span className="text-white font-bold text-xs">X</span>
-                </button>
-            </div>
-            )}
-
-            <div className='relative ml-6 mt-6'> 
-                <img
-                    className='w-32 h-32 rounded-full border-2 border-white shadow-lg object-cover'
-                    // src={authUser.profileAvatar?.url}
-                    src={avatarSrc}
-                    alt='Avatar'
-                />
-                
-                {/* Hidden file input and attached to the pencil icon*/}
-                {/* ofc this can be done with a "label" instead of ref */}
-                <input
-                    type="file"
-                    accept="image/*"
-                    id="avatar-upload"
-                    name="profileAvatarFile"
-                    ref={avatarInputRef}
-                    onChange={handleImageFileChange}
-                    className="hidden"
-                />
-
-                {selectedImages.avatar.preview && (
-                <div className='absolute top-0 left-20 '>
-                    <button
-                        className='relative w-8 h-8 bg-red-500 rounded-full flex justify-center items-center hover:bg-red-600'
-                        onClick={() => handleRemoveImage('avatar')}
-                        aria-label="Remove avatar"
-                    >
-                        <span className="text-white text-sm font-bold">×</span>
-                    </button>
-                </div>
-                )}
-                    
-                <button 
-                    className='absolute bottom-0 left-3 p-1 bg-grey rounded-full cursor-pointer hover:bg-gray-300 group'
-                    onClick={() => avatarInputRef.current?.click()} //that trigger input 'onClick'
-                >
-                    <PiPencil className='text-xl text-gray-600 group-hover:text-gray-800'/>
-                </button>
-
-            </div>
-        </div>
+        
+        <ProfileHeader
+            backgroundSrc={backgroundSrc}
+            avatarSrc={avatarSrc}
+            backgroundInputRef={backgroundInputRef}
+            avatarInputRef={avatarInputRef}
+            selectedImages={selectedImages}
+            onImageFileChange={onImageFileChange}
+            onRemoveImage={onRemoveImage}
+        />
 
         <div className='flex justify-end gap-x-3'>
             <SocialLinks links={userData.socialLinks!}/>
         </div>
 
-        {/* Row 1 - FarmName (half width) */}
-        <div className="w-full md:w-1/2 md:pr-2">
-            <label htmlFor="farmerName" className="text-sm font-medium text-gray-700">
-            Farm Name
-            </label>
-            <TextField
-                className={`
-                    w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
-                    focus:border-green2 focus:border-4
-                    ${getBorderErrorStyle('farmName')}
-                `}
-                id="farmerName"
-                value={userData.farmName}
-                name="farmName"
-                type="text"
-                placeholder="Enter Farm Name"
-                onChange={handleChange}
-            />
-            {validationErrors.farmName &&
-                <label className='text-red-600 text-sm'>{validationErrors.farmName}</label>
-            }
-        </div>
-    
-        {/* Row 2 - FirstName & LastName */}
-        <div className="flex flex-col md:flex-row gap-4 ">
-            <div className="w-full md:w-1/2">
-                <label htmlFor="firstName" className="text-sm font-medium text-gray-700">
-                    First Name
-                </label>
-                <TextField
-                    className={`
-                        w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
-                        focus:border-green2 focus:border-4
-                        ${getBorderErrorStyle('firstName')}
-                    `}
-                    id="firstName" //match label htmlFor 
-                    value={userData.firstName}
-                    name="firstName"
-                    type="text"
-                    placeholder='Enter First Name'
-                    // onChange={(e: React.ChangeEvent<HTMLInputElement>) =>{
-                    //     setUserData({ ...userData, firstName: e.target.value})
-                    // }}
-                    onChange={handleChange}
-                />
-                {validationErrors.firstName &&
-                    <label className='text-red-600 text-sm'> {validationErrors.firstName}</label>
-                }
-            </div>
-            <div className="w-full md:w-1/2">
-                <label htmlFor="lastName" className="text-sm font-medium text-gray-700">
-                    Last Name
-                </label>
-                <TextField
-                    className={`
-                        w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
-                        focus:border-green2 focus:border-4
-                        ${getBorderErrorStyle('lastName')}
-                    `}
-                    id="lastName" //match label htmlFor 
-                    // value={userData.fullName.split('')[1]}
-                    value={userData.lastName}
-                    name="lastName"
-                    type="text"
-                    placeholder="Enter Last Name"
-                    onChange={handleChange}
-                />
-                {validationErrors.lastName &&
-                    <label className='text-red-600 text-sm'> {validationErrors.lastName}</label>
-                }  
-            </div>
-        </div>
+        <InfoForm 
+            userData={userData}
+            authUser={authUser}
+            validationErrors={validationErrors}
+            onChange={handleChange}
+            getBorderErrorStyle={getBorderErrorStyle}
+            handleSocialChange={handleSocialChange}
+        />        
 
-        {/* Row 3 - Username & Email */}
-        <div className="flex flex-col md:flex-row gap-4">
-            <div className="w-full md:w-1/2">
-                <label htmlFor="username" className="text-sm font-medium text-gray-700">
-                    Username
-                </label>
-                <TextField
-                    className={`
-                        w-full p-2 pl-4 border-2 rounded-md shadow-sm 
-                        bg-greySbtn text-gray-600
-                    `}
-                    value={authUser.username}
-                    disabled
-                    onChange={()=>{}}
-                />
-            </div>
-            <div className="w-full md:w-1/2">
-                <label htmlFor="username" className="text-sm font-medium text-gray-700">
-                    Email
-                </label>
-                <TextField
-                    className={`
-                        w-full p-2 pl-4 border-2 rounded-md shadow-sm 
-                        bg-greySbtn text-gray-500
-                    `}
-                    value={authUser.email}
-                    disabled
-                    onChange={()=>{}}
-                />
-            </div>
-        </div>
-
-        {/* Row 4 - Phone Number (half width) */}
-        <div className="w-full md:w-1/2 md:pr-2">
-            <label htmlFor="phoneNumber" className="text-sm font-medium text-gray-700">
-                Phone Number
-            </label>
-            <TextField
-                className={`
-                    w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
-                    focus:border-green2 focus:border-4
-                    ${getBorderErrorStyle('phoneNumber')}
-                `}
-                id="phoneNumber"
-                value={userData.phoneNumber}
-                name="phoneNumber"
-                type="tel"
-                placeholder="+381 or 06x"
-                onChange={handleChange}
-            />
-            {validationErrors.phoneNumber &&
-                <label className='text-red-600 text-sm'>{validationErrors.phoneNumber}</label>
-            }
-        </div>
-
-        {/* Row 6 - City & Address */}
-        <div className="flex flex-col md:flex-row gap-4">
-            <div className="w-full md:w-1/2">
-                <label htmlFor="city" className="text-sm font-medium text-gray-700">
-                City
-                </label>
-                <SelectField 
-                    className={`p-[11px] pl-4 bg-white text-gray-500 ${getBorderErrorStyle('location')}`}
-                    id='city'
-                    name='location.city'
-                    value={userData.location?.city ?? ''}
-                    options={CITIES}
-                    onChange={handleChange}
-                />
-                {validationErrors.location &&
-                    <label className='text-red-600 text-sm'>{validationErrors.location}</label>
-                }
-            </div>
-            <div className="w-full md:w-1/2">
-                <label htmlFor="address" className="text-sm font-medium text-gray-700">
-                Address
-                </label>
-                <TextField
-                    className={`
-                        w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
-                        focus:border-green2 focus:border-4
-                        ${getBorderErrorStyle('address')}
-                    `}
-                    id="address"
-                    name="location.address"
-                    value={userData.location?.address}
-                    type="text"
-                    placeholder="Address"
-                    onChange={handleChange}
-                />
-                {validationErrors.location &&
-                    <label className='text-red-600 text-sm'>{validationErrors.location}</label>
-                }
-            </div>
-        </div>
-
-        {/* Row 8 - Description (full width) */}
-        <div className="w-full ">
-            <label htmlFor="description" className="text-sm font-medium text-gray-700">
-                Description
-            </label>
-            <textarea
-                className='w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4'
-                id="description"
-                name='description'
-                value={userData.description}
-                placeholder="Enter a detailed description to be shown on the full profile"
-                onChange={handleChange}
-            >
-            </textarea>
-            {validationErrors.description &&
-                <label className='text-red-600 text-sm'>{validationErrors.description}</label>
-            }
-        </div>
-
-        <div className='w-full'>
-            <label htmlFor="description" className="text-sm font-medium text-gray-700">
-               Map Location
-            </label>
-            <div className=''>
-                <TextField
-                    className={`
-                        
-                    `}
-                    id="location"
-                    name="location"
-                    value={userData.location?.address}
-                    type="radio"
-                    placeholder="Address"
-                    // onChange={handleChange}
-                />
-                <label> Use your location (enable it)</label>
-            </div>
-            <div className=''>
-                <TextField
-                    className={`
-                        
-                    `}
-                    id="location"
-                    name="location"
-                    value={userData.location?.address}
-                    type="radio"
-                    placeholder="Address"
-                    // onChange={handleChange}
-                />
-                <label> Select manually your location </label>
-            </div>
-
-
-            <div className='google map'>
-
-            </div>
-        </div>
-
-
-        <div className="w-full md:w-1/2">
-            <label htmlFor="social" className="text-sm font-medium text-gray-700 ">
-                Social
-            </label>
-            {userData.socialLinks?.map((el, index) => (
-                <div key={`${el.name}`} className='my-2'>
-                    <label  htmlFor={el.name} className="text-sm font-medium text-gray-700">
-                        {`${el.name}`}
-                    </label>
-                    <TextField
-                        className={`
-                            w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
-                            focus:border-green2 focus:border-4
-                            ${getBorderErrorStyle('social')}
-                        `}
-                        id="el.name"
-                        name={el.name}
-                        value={el.url || ''}
-                        type="text"
-                        placeholder={`Enter ${el.name} link`}
-                        onChange={(e) => handleSocialChange(index, e.target.value)}
-                    />
-                </div>
-            ))}
-        </div>
+        <ProfileImages
+            existingImages={existingProfileImages}
+            previewImages={profileImages.previews}
+            onImagesChange={onProfileImagesChange}
+            onRemoveExisting={handleRemoveExistingProfileImage}
+            onRemovePreview={onRemovePreviewProfileImage}
+        />
                     
-        
-        <button 
-            className="w-full max-w-[300px] mx-auto p-2 mt-6 border-2 rounded-md text-white font-semibold bg-green7" 
-            onClick={onSubmitHandler}
-        > Apply Changes
-        </button>
+        <div className='w-full flex justify-center items-center gap-3'>  
+            <button 
+                className="w-full max-w-[300px] p-2 border-2 ml-2 rounded-md text-white font-semibold bg-green7" 
+                onClick={onSubmitHandler}
+            > 
+                Apply Changes
+            </button>
+
+            {uploadLoading &&
+            <div>
+                <LoadingSpinner
+                    spinnerClassName='text-green5'
+                />
+            </div>
+            }
+        </div>
     </div>
   );
 }

--- a/client/src/features/farmer/components/GalleryGrid.tsx
+++ b/client/src/features/farmer/components/GalleryGrid.tsx
@@ -3,7 +3,7 @@ import "react-photo-album/masonry.css";
 import PhotoAlbum from "react-photo-album";
 import { GalleryImageInterface } from '../farmer.interface';
 
-const FarmerGalleryGrid:FC<{images: GalleryImageInterface[]}> = ({ images }): ReactElement => {
+const GalleryGrid:FC<{images: GalleryImageInterface[]}> = ({ images }): ReactElement => {
 
     const photos = images.slice(0,6).map(img => ({ //first 6 images
         src: img.url,
@@ -13,8 +13,8 @@ const FarmerGalleryGrid:FC<{images: GalleryImageInterface[]}> = ({ images }): Re
 
     return (
         <div className='w-full max-w-[800px]a mx-auto'>
-
-            {photos.length > 6 && 
+            {/* BUG FIXED: replace photo.length (that is always 6 due to .slice(0,6)) to images.length */}
+            {images.length > 6 && 
                 <div className='w-full flex justify-end'>
                     <button 
                         className='font-lato text-sm sm:text-base border rounded-lg border-black p-2 hover:bg-grey'
@@ -50,4 +50,4 @@ const FarmerGalleryGrid:FC<{images: GalleryImageInterface[]}> = ({ images }): Re
     )
 }
 
-export default FarmerGalleryGrid
+export default GalleryGrid

--- a/client/src/features/farmer/components/InfoForm.tsx
+++ b/client/src/features/farmer/components/InfoForm.tsx
@@ -1,0 +1,238 @@
+import SelectField from "../../shared/inputs/SelectField";
+import TextField from "../../shared/inputs/TextField";
+import { CITIES } from "../../shared/utils/data";
+
+import { InfoFormProps } from "../farmer.interface";
+
+const InfoForm: React.FC<InfoFormProps> = ({
+    userData,
+    authUser,
+    validationErrors,
+    onChange,
+    getBorderErrorStyle,
+    handleSocialChange
+}) => {
+    return (
+        <>
+            <div className="w-full md:w-1/2 md:pr-2">
+                <label htmlFor="farmerName" className="text-sm font-medium text-gray-700">
+                    Farm Name
+                </label>
+                <TextField
+                    className={`w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4 ${getBorderErrorStyle('farmName')}`}
+                    id="farmerName"
+                    value={userData.farmName}
+                    name="farmName"
+                    type="text"
+                    placeholder="Enter Farm Name"
+                    onChange={onChange}
+                />
+                {validationErrors.farmName && (
+                    <label className='text-red-600 text-sm'>{validationErrors.farmName}</label>
+                )}
+            </div>
+
+            {/* First & Last Name */}
+            <div className="flex flex-col md:flex-row gap-4">
+                <div className="w-full md:w-1/2">
+                    <label htmlFor="firstName" className="text-sm font-medium text-gray-700">
+                        First Name
+                    </label>
+                    <TextField
+                        className={`w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4 ${getBorderErrorStyle('firstName')}`}
+                        id="firstName"
+                        value={userData.firstName}
+                        name="firstName"
+                        type="text"
+                        placeholder='Enter First Name'
+                        onChange={onChange}
+                    />
+                    {validationErrors.firstName && (
+                        <label className='text-red-600 text-sm'>{validationErrors.firstName}</label>
+                    )}
+                </div>
+                
+                <div className="w-full md:w-1/2">
+                    <label htmlFor="lastName" className="text-sm font-medium text-gray-700">
+                        Last Name
+                    </label>
+                    <TextField
+                        className={`w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4 ${getBorderErrorStyle('lastName')}`}
+                        id="lastName"
+                        value={userData.lastName}
+                        name="lastName"
+                        type="text"
+                        placeholder="Enter Last Name"
+                        onChange={onChange}
+                    />
+                    {validationErrors.lastName && (
+                        <label className='text-red-600 text-sm'>{validationErrors.lastName}</label>
+                    )}  
+                </div>
+            </div>
+
+            {/* Username & Email (Read-only) */}
+            <div className="flex flex-col md:flex-row gap-4">
+                <div className="w-full md:w-1/2">
+                    <label htmlFor="username" className="text-sm font-medium text-gray-700">
+                        Username
+                    </label>
+                    <TextField
+                        className="w-full p-2 pl-4 border-2 rounded-md shadow-sm bg-greySbtn text-gray-600"
+                        value={authUser.username}
+                        disabled
+                        onChange={() => {}}
+                    />
+                </div>
+                <div className="w-full md:w-1/2">
+                    <label htmlFor="email" className="text-sm font-medium text-gray-700">
+                        Email
+                    </label>
+                    <TextField
+                        className="w-full p-2 pl-4 border-2 rounded-md shadow-sm bg-greySbtn text-gray-500"
+                        value={authUser.email}
+                        disabled
+                        onChange={() => {}}
+                    />
+                </div>
+            </div>
+
+            {/* Phone Number */}
+            <div className="w-full md:w-1/2 md:pr-2">
+                <label htmlFor="phoneNumber" className="text-sm font-medium text-gray-700">
+                    Phone Number
+                </label>
+                <TextField
+                    className={`w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4 ${getBorderErrorStyle('phoneNumber')}`}
+                    id="phoneNumber"
+                    value={userData.phoneNumber}
+                    name="phoneNumber"
+                    type="tel"
+                    placeholder="+381 or 06x"
+                    onChange={onChange}
+                />
+                {validationErrors.phoneNumber && (
+                    <label className='text-red-600 text-sm'>{validationErrors.phoneNumber}</label>
+                )}
+            </div>
+
+            {/* City & Address */}
+            <div className="flex flex-col md:flex-row gap-4">
+                <div className="w-full md:w-1/2">
+                    <label htmlFor="city" className="text-sm font-medium text-gray-700">
+                        City
+                    </label>
+                    <SelectField 
+                        className={`p-[11px] pl-4 bg-white text-gray-500 ${getBorderErrorStyle('location')}`}
+                        id='city'
+                        name='location.city'
+                        value={userData.location?.city ?? ''}
+                        options={CITIES}
+                        onChange={onChange}
+                    />
+                    {validationErrors.location && (
+                        <label className='text-red-600 text-sm'>{validationErrors.location}</label>
+                    )}
+                </div>
+                <div className="w-full md:w-1/2">
+                    <label htmlFor="address" className="text-sm font-medium text-gray-700">
+                        Address
+                    </label>
+                    <TextField
+                        className={`w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4 ${getBorderErrorStyle('address')}`}
+                        id="address"
+                        name="location.address"
+                        value={userData.location?.address}
+                        type="text"
+                        placeholder="Address"
+                        onChange={onChange}
+                    />
+                    {validationErrors.location && (
+                        <label className='text-red-600 text-sm'>{validationErrors.location}</label>
+                    )}
+                </div>
+            </div>
+
+            {/* Description */}
+            <div className="w-full">
+                <label htmlFor="description" className="text-sm font-medium text-gray-700">
+                    Description
+                </label>
+                <textarea
+                    className='w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm focus:border-green2 focus:border-4'
+                    id="description"
+                    name='description'
+                    value={userData.description}
+                    placeholder="Enter a detailed description to be shown on the full profile"
+                    onChange={onChange}
+                />
+                {validationErrors.description && (
+                    <label className='text-red-600 text-sm'>{validationErrors.description}</label>
+                )}
+            </div>
+
+            <div className='w-full'>
+                <label htmlFor="description" className="text-sm font-medium text-gray-700">
+                    Map Location
+                </label>
+                <div className=''>
+                    <TextField
+                        className={``}
+                        id="location"
+                        name="location"
+                        value={userData.location?.address}
+                        type="radio"
+                        placeholder="Address"
+                        // onChange={handleChange}
+                    />
+                    <label> Use your location (enable it)</label>
+                </div>
+                <div className=''>
+                    <TextField
+                        className={``}
+                        id="location"
+                        name="location"
+                        value={userData.location?.address}
+                        type="radio"
+                        placeholder="Address"
+                        // onChange={handleChange}
+                    />
+                    <label> Select manually your location </label>
+                </div>
+
+
+                <div className='google map'>
+
+                </div>
+            </div>
+
+            <div className="w-full md:w-1/2">
+            <label htmlFor="social" className="text-sm font-medium text-gray-700 ">
+                Social
+            </label>
+            {userData.socialLinks?.map((el, index) => (
+                <div key={`${el.name}`} className='my-2'>
+                    <label  htmlFor={el.name} className="text-sm font-medium text-gray-700">
+                        {`${el.name}`}
+                    </label>
+                    <TextField
+                        className={`
+                            w-full p-2 pl-4 border-2 border-greyB rounded-md shadow-sm 
+                            focus:border-green2 focus:border-4
+                            ${getBorderErrorStyle('social')}
+                        `}
+                        id="el.name"
+                        name={el.name}
+                        value={el.url || ''}
+                        type="text"
+                        placeholder={`Enter ${el.name} link`}
+                        onChange={(e) => handleSocialChange(index, e.target.value)}
+                    />
+                </div>
+            ))}
+        </div>
+        </>
+    );
+};
+
+export default InfoForm;

--- a/client/src/features/farmer/components/ProfileHeader.tsx
+++ b/client/src/features/farmer/components/ProfileHeader.tsx
@@ -1,0 +1,98 @@
+import { FC, ReactElement } from "react"
+import { ProfileHeaderProps } from "../farmer.interface"
+import { PiPencil } from "react-icons/pi"
+
+
+const ProfileHeader:FC<ProfileHeaderProps>= ({
+    backgroundSrc,
+    avatarSrc,
+    backgroundInputRef,
+    avatarInputRef,
+    selectedImages,
+    onImageFileChange,
+    onRemoveImage
+}):ReactElement => {
+    return (
+        <div 
+            className='relative w-full h-56 bg-cover bg-center overflow-hidden rounded '
+            // style={{ backgroundImage: `url(${authUser.backgroundImage?.url})`}}
+            style={{ backgroundImage: `url(${backgroundSrc})`}}
+        >
+            {/* Hidden file input and attached to the pencil icon*/}
+            {/* ofc this can be done with a "label" instead of ref */}
+            <input
+                type="file"
+                accept="image/*"
+                id="background-upload"
+                name="backgroundImageFile"
+                ref={backgroundInputRef}
+                onChange={onImageFileChange}
+                className="hidden"
+            />
+            <button 
+                className='absolute left-2 bottom-2 p-1 bg-grey rounded cursor-pointer hover:bg-gray-300 group'
+                // onClick={onEditProfileAvatar}
+                onClick={() => backgroundInputRef.current?.click()}
+            >
+                <PiPencil className='text-2xl text-gray-600 group-hover:text-gray-800'/>
+            </button>
+
+            {/* Remove Button (only shows when new background is selected) */}
+            {selectedImages.background.preview && (
+            <div className='absolute top-2 right-2 w-8 h-8 group'>
+                <button
+                    // className='w-full h-full cursor-pointer  '
+                    className="w-full h-full cursor-pointer bg-red-500 group-hover:bg-red-600 rounded-full flex justify-center items-center"
+                    onClick={() => onRemoveImage('background')}
+                >
+                    {/* <div className="w-full h-full text-white font-bold text-sm flex justify-center items-center bg-red-500 rounded-full border group-hover:bg-red-600">X</div> */}
+                    <span className="text-white font-bold text-xs">X</span>
+                </button>
+            </div>
+            )}
+
+            <div className='relative ml-6 mt-6'> 
+                <img
+                    className='w-32 h-32 rounded-full border-2 border-white shadow-lg object-cover'
+                    // src={authUser.profileAvatar?.url}
+                    src={avatarSrc}
+                    alt='Avatar'
+                />
+                
+                {/* Hidden file input and attached to the pencil icon*/}
+                {/* ofc this can be done with a "label" instead of ref */}
+                <input
+                    type="file"
+                    accept="image/*"
+                    id="avatar-upload"
+                    name="profileAvatarFile"
+                    ref={avatarInputRef}
+                    onChange={onImageFileChange}
+                    className="hidden"
+                />
+
+                {selectedImages.avatar.preview && (
+                <div className='absolute top-0 left-20 '>
+                    <button
+                        className='relative w-8 h-8 bg-red-500 rounded-full flex justify-center items-center hover:bg-red-600'
+                        onClick={() => onRemoveImage('avatar')}
+                        aria-label="Remove avatar"
+                    >
+                        <span className="text-white text-sm font-bold">×</span>
+                    </button>
+                </div>
+                )}
+                    
+                <button 
+                    className='absolute bottom-0 left-3 p-1 bg-grey rounded-full cursor-pointer hover:bg-gray-300 group'
+                    onClick={() => avatarInputRef.current?.click()} //that trigger input 'onClick'
+                >
+                    <PiPencil className='text-xl text-gray-600 group-hover:text-gray-800'/>
+                </button>
+
+            </div>
+        </div>
+    )
+}
+
+export default ProfileHeader

--- a/client/src/features/farmer/components/ProfileImages.tsx
+++ b/client/src/features/farmer/components/ProfileImages.tsx
@@ -1,0 +1,73 @@
+import uploadImage from '../../../assets/upload.svg';
+import { ProfileImagesProps } from "../farmer.interface";
+
+const ProfileImages: React.FC<ProfileImagesProps> = ({
+    existingImages,
+    previewImages,
+    onImagesChange,
+    onRemoveExisting,
+    onRemovePreview
+}) => {
+    return (
+    <div className="w-full">
+        <label className="text-md font-medium text-gray-700">Profile Images</label>
+        <p className="py-1 text-xs text-gray-500">
+            The first image in the list will be used as the main display picture.
+        </p>
+
+        <div className="w-full max-w-[780px] flex flex-wrap border-2 border-greyB rounded-md">
+        <input
+            type="file"
+            multiple
+            accept="image/*"
+            onChange={onImagesChange}
+            className="hidden"
+            id="profile-images-upload"
+        />
+        
+        <label
+            htmlFor="profile-images-upload"
+            className="w-44 h-32 p-4 m-2 flex flex-col border border-greyB rounded-md bg-grey font-lato text-gray-500 cursor-pointer hover:bg-gray-300 hover:border-black group"
+        >
+            <div className="mt-2 flex flex-col justify-center items-center">
+                <img src={uploadImage} alt="upload" className="w-6 h-6" />
+                <div className="font-medium group-hover:text-black">
+                    Click to upload
+                </div>
+            </div>
+            <p className="mt-2 text-xs text-center group-hover:text-black">
+                SVG, PNG, JPG or GIF
+            </p>
+        </label>
+
+        {/* Existing images */}
+        {existingImages?.map((img, index) => (
+            <div key={`db-${index}`} className="relative w-44 h-32 m-2 border border-greyB rounded-md">
+                <img src={img.url} alt={`Profile ${index}`} className="w-44 h-32 rounded-md object-cover" />
+                <button
+                    className="absolute top-1 left-1 w-7 h-7 bg-white text-red-800 text-xs font-medium rounded-md cursor-pointer hover:text-red-900"
+                    onClick={() => onRemoveExisting(index)}
+                >
+                    X
+                </button>
+            </div>
+        ))}
+
+        {/* Preview images */}
+        {previewImages.map((url, index) => (
+            <div key={`preview-${index}`} className="relative w-44 h-32 m-2 border border-greyB rounded-md">
+                <img src={url} alt="Preview" className="w-44 h-32 rounded-md object-cover" />
+                <button
+                    className="absolute top-1 left-1 w-7 h-7 bg-white text-red-800 text-xs font-medium rounded-md cursor-pointer hover:text-red-900"
+                    onClick={() => onRemovePreview(index)}
+                >
+                    X
+                </button>
+            </div>
+        ))}
+        </div>
+    </div>
+    );
+};
+
+export default ProfileImages

--- a/client/src/features/farmer/farmer.interface.ts
+++ b/client/src/features/farmer/farmer.interface.ts
@@ -1,5 +1,6 @@
-import { FarmerLocationInterface } from "../auth/auth.interfaces";
+import { AuthUserInterface, FarmerLocationInterface } from "../auth/auth.interfaces";
 import { ProductDocumentInterface } from "../product/product.interface";
+import { ValidationErrorMap } from "../shared/hooks/useSchemaValidation";
 
 export interface FarmerProductsTableInterface {
     id: string,
@@ -21,6 +22,7 @@ export interface FarmerProfileInterface {
     location?: FarmerLocationInterface,
     profileAvatarFile?: string,
     backgroundImageFile?: string,
+    profileImagesFile?: string[],
     // profileAvatarImages?: string[],
     description?: string,
     socialLinks?: { name: string, url: string }[],
@@ -47,12 +49,15 @@ export interface FarmerDocumentInterface {
         url: string;
         publicID: string;
     };
-    profileImages?: [
-        {
-            url: string;
-            publicID: string;
-        }
-    ];
+    profileImages?:
+    {
+        url: string;
+        publicID: string;
+    }[];
+    //publicID's for images that will be removed from cloudinary
+    removedImages?: [
+        publicID: string 
+    ]
     fullName?: string;
     farmName?: string;
     location?: {
@@ -92,4 +97,31 @@ export interface GalleryImageInterface {
 export interface OrderFilterOptionsInterface {
     sort?: 'newest' | 'oldest' | 'requested' | 'accepted' | 'packaged' | 'toCurier' | 'delivered' | 'canceled';
     size?: number;
+}
+
+export interface ProfileHeaderProps {
+    backgroundSrc: string;
+    avatarSrc: string;
+    backgroundInputRef: React.RefObject<HTMLInputElement | null>;
+    avatarInputRef: React.RefObject<HTMLInputElement | null>;
+    selectedImages: any;
+    onImageFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onRemoveImage: (type: 'avatar' | 'background') => void;
+}
+
+export interface InfoFormProps {
+    userData: FarmerProfileInterface;
+    authUser: AuthUserInterface;
+    validationErrors: ValidationErrorMap;
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => void;
+    getBorderErrorStyle: (field: string) => string;
+    handleSocialChange: (index: number, value: string) => void;
+}
+
+export interface ProfileImagesProps {
+    existingImages: { url: string; publicID: string }[];
+    previewImages: string[];
+    onImagesChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onRemoveExisting: (index: number) => void;
+    onRemovePreview: (index: number) => void;
 }

--- a/client/src/features/hooks/useFarmerProfile.tsx
+++ b/client/src/features/hooks/useFarmerProfile.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react";
+import { useAppDispatch } from '../../store/store';
+import toast from 'react-hot-toast';
+
+import { useUpdateFarmerMutation } from "../farmer/farmer.service";
+import { useSchemaValidation } from "../shared/hooks/useSchemaValidation";
+
+import { farmerProfileSchema } from '../farmer/farmer.schema';
+import { SOCIAL } from "../shared/utils/data";
+import { mapFarmerToAuthUser } from "../shared/utils/utilsFunctions";
+import { updateAuthUser } from "../auth/auth.reducers";
+
+import { FarmerProfileInterface, FarmerDocumentInterface} from "../farmer/farmer.interface";
+import { AuthUserInterface, FarmerLocationInterface } from "../auth/auth.interfaces";
+
+const useFarmerProfile = (authUser: AuthUserInterface) => {
+    const dispatch = useAppDispatch();
+
+    const [ updateFarmer, { isLoading:uploadLoading } ] = useUpdateFarmerMutation();
+    
+    const [userData, setUserData] = useState<FarmerProfileInterface>({
+        farmName: authUser.farmName,
+        firstName: authUser.fullName.split(' ')[0],
+        lastName: authUser.fullName.split(' ')[1],
+        phoneNumber: authUser.phoneNumber,
+        location: {
+            longitude:'',
+            latitude:'',
+            country:authUser.location.country,
+            city:authUser.location.city,
+            address:authUser.location.address,
+        }, 
+        profileAvatarFile: '',
+        backgroundImageFile: '', 
+        profileImagesFile: [],
+        description: authUser.description, 
+
+        //from backend we got socialLinks as string array
+        socialLinks: SOCIAL.map((el) => {
+            const existingUrl = authUser.socialLinks?.find((url: string) =>
+                url.toLowerCase().includes(el.name.toLowerCase())
+            );
+
+            return {
+                name: el.name,
+                url: existingUrl || '',
+            };
+        }),
+    });
+
+    const [schemaValidation, validationErrors, resetValidationErrors] = useSchemaValidation({
+        schema: farmerProfileSchema, 
+        userData
+    });
+
+    const getChangedFields = (original: any, updated: any) => {
+        const changes: any = {};
+
+        const { firstName, lastName, ...updatedData } = updated;
+
+        const mergedData = {
+            ...updatedData,
+            fullName: `${firstName} ${lastName}`
+        };
+
+        for (const key in mergedData) {
+
+            if (key === 'location') {
+                const locationChanges: any = {};
+                const updatedLocation = mergedData.location || {};
+                const originalLocation = original?.location || {};
+
+                for (const locKey in updatedLocation) {
+                    // Only include if field exists in original OR the updated value is not empty
+                    const updatedVal = updatedLocation[locKey];
+                    const originalVal = originalLocation[locKey];
+
+                    if ( updatedVal !== originalVal && (originalVal !== undefined || updatedVal !== '')) {
+                        locationChanges[locKey] = updatedVal;
+                    }
+                }
+
+                if (Object.keys(locationChanges).length > 0) {
+                    changes.location = locationChanges;
+                }
+            }
+
+            else if (key === 'socialLinks') {
+                const originalLinks = original[key] || [];
+                const updatedLinks = mergedData[key] || [];
+
+                const bothEmpty = originalLinks.length === 0 && updatedLinks.length === 0;
+
+                if (!bothEmpty && JSON.stringify(originalLinks) !== JSON.stringify(updatedLinks)) {
+                    changes[key] = updatedLinks;
+                }
+            }
+
+            else if (key === 'profileAvatarFile' || key === 'backgroundImageFile') {
+                // Only include if actually set
+                if (mergedData[key] && mergedData[key] !== '') {
+                    changes[key] = mergedData[key];
+                }
+            }
+
+            else if (key === 'profileImagesFile' || key === 'removedImages') {
+                if (Array.isArray(mergedData[key]) && mergedData[key].length > 0) {
+                    changes[key] = mergedData[key];
+                }
+            }
+
+            else {
+                if (mergedData[key] !== original?.[key]) {
+                    changes[key] = mergedData[key];
+                }
+            }
+        }
+        return changes;
+    };
+
+    const handleSubmit = async(additionalData = {}):Promise<FarmerDocumentInterface> =>{
+        const isValid = await schemaValidation(); 
+
+        if(!isValid){
+            toast.error("Validation Field error"); //think to call toast.error in caller component
+            throw new Error("Validation failed");
+        }
+
+        //transform socialLinks objects to string array
+        const social = userData.socialLinks
+            ?.filter((link) => link.url.trim() !== '')
+            .map((link) => link.url)
+
+        console.log("USER DDDDD : ", userData);
+
+        const newData = getChangedFields(
+            authUser, 
+            {
+                ...userData,
+                socialLinks:social,
+                // removedImages //Data from others hooks(parts) 
+                ...additionalData
+            });
+        console.log("Changes DaTA: ", newData);
+
+        if(Object.keys(newData).length === 0 ){
+            toast.error("You didn't pass any data!");
+            throw new Error("You didn't pass any data");
+            // return;
+        }
+
+        try{
+            if(!authUser.id) throw new Error("You don't have permission to updates");
+    
+            const farmerID = authUser?.id.toString();
+            const result = await updateFarmer({ farmerID, updateData: newData })
+            const newUpdatedData = result?.data?.farmer;
+
+            if(!newUpdatedData)
+                throw new Error("Validation failed, no data returend from update");
+            
+            const mappedData = mapFarmerToAuthUser(newUpdatedData, authUser);
+            dispatch(updateAuthUser(mappedData));
+            
+            toast.success("Successfully updated Profile")
+            return newUpdatedData;
+        }   
+        catch(error){
+            console.log("Error update Farmer: ", error);
+            // -> throw error on called func that will call it with try/catch
+            throw error;
+        }
+    }
+
+    const handleChange = (
+            e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+        ): void => {
+            const { name, value } = e.target;
+    
+            //handling location object with {city and address prop}
+            if(name.startsWith("location.")) { 
+                //example for city -> name:location.city
+                const locationField = name.split('.')[1];//is 'city value'
+                setUserData(prev => ({
+                    ...prev,
+                    location: {
+                        ...prev.location,
+                        [locationField]: value
+                    } as FarmerLocationInterface
+                }));
+            }
+            else { 
+                setUserData(prev => ({
+                    ...prev,
+                    [name]: value
+                }));
+            }
+        };
+
+    const getBorderErrorStyle = (field: string): string => {
+        return validationErrors[field] ? 'border-0 border-b-4 border-red-400' : '';
+    };
+
+    return {
+        userData, 
+        setUserData,
+        uploadLoading,
+        validationErrors,
+        getChangedFields,
+        handleSubmit,
+        handleChange,
+        getBorderErrorStyle
+    }
+}
+
+export default useFarmerProfile

--- a/client/src/features/hooks/useProfileHeaderImages.tsx
+++ b/client/src/features/hooks/useProfileHeaderImages.tsx
@@ -1,0 +1,72 @@
+import { ChangeEvent, useState, useRef } from 'react';
+import { readAsBase64 } from '../shared/utils/utilsFunctions';
+
+const useProfileHeaderImages = () => {
+    const backgroundInputRef = useRef<HTMLInputElement>(null);
+    const avatarInputRef = useRef<HTMLInputElement>(null);
+
+    const [selectedImages, setSelectedImages] = useState({
+        avatar: {
+            file: null as File | null,
+            preview: null as string | null
+        },
+        background: {
+            file: null as File | null,
+            preview: null as string | null
+        }
+    });
+
+    const handleImageFileChange = async ( 
+        e: ChangeEvent<HTMLInputElement>,
+        onUpdateImageFile: (name:string, base64File: string) => void,
+    ): Promise<void> => {
+        const file = e.target.files?.[0];
+        const name = e.target.name;
+        if(!file) return;
+
+        const preview = URL.createObjectURL(file);
+ 
+        setSelectedImages(prev => ({
+            ...prev,
+            [name === 'profileAvatarFile' ? 'avatar' : 'background']: {
+                file,
+                preview
+            }
+        }));
+
+        try{
+            const base64 = await readAsBase64(file);
+            onUpdateImageFile(name, base64);
+        }
+        catch(error){
+            console.error("Faild to process avatar file:", error);
+        }
+    }
+
+    const handleRemoveImage = (
+        type: 'avatar' | 'background',
+        onUpdateImage: () => void
+    ) => {
+        // Clean up object URL
+        if (selectedImages[type].preview) {
+            URL.revokeObjectURL(selectedImages[type].preview!);
+        }
+
+        setSelectedImages(prev => ({
+            ...prev,
+            [type]: { file: null, preview: null }
+        }));
+
+        onUpdateImage();
+    };
+
+    return {
+        backgroundInputRef,
+        avatarInputRef,
+        selectedImages,
+        handleImageFileChange,
+        handleRemoveImage
+    }
+}
+
+export default useProfileHeaderImages

--- a/client/src/features/hooks/useProfileImages.tsx
+++ b/client/src/features/hooks/useProfileImages.tsx
@@ -1,0 +1,75 @@
+import { ChangeEvent, useState} from 'react';
+import { readAsBase64 } from '../shared/utils/utilsFunctions';
+import { AuthUserInterface } from '../auth/auth.interfaces';
+
+//get auth from faremerProfile.tsx ()
+const useProfileImages = (authUser: AuthUserInterface) => {
+    const [profileImages, setProfileImages] = useState<{
+        files: File[],
+        previews: string[];
+    }>({files: [], previews: []})
+
+    const [existingProfileImages, setExistingProfileImages] = useState<{ url: string; publicID: string }[]>(
+        authUser.profileImages || []
+    );
+    //seperated state for removing existing images
+    const [removedImages, setRemovedImages] = useState<string[]>([]);
+
+    const handleProfileImagesChange = async (
+        e:ChangeEvent<HTMLInputElement>, 
+        onUpdate: (base64Files: string[]) => void
+    ) :Promise<void> => {
+        //onUpdate is callback
+        const files = e.target.files;
+        if(!files) return;
+
+        const selectedFiles = Array.from(files);
+        const previews = selectedFiles.map((file) => URL.createObjectURL(file));
+
+        const base64Files = await Promise.all(selectedFiles.map(readAsBase64));
+
+        setProfileImages((prev) => ({
+            files: [...prev.files, ...selectedFiles],
+            previews: [...prev.previews, ...previews]
+        }));
+
+        onUpdate(base64Files);
+    }
+
+    const handleRemovePreviewProfileImage = (
+        index: number,
+        onUpdateFiles: (index: number) => void
+    ) => {
+        setProfileImages((prev) => {
+            URL.revokeObjectURL(prev.previews[index]);
+
+            return {
+                files: prev.files.filter((_, i) => i !== index),
+                previews: prev.previews.filter((_, i) => i !== index),
+            };
+        });
+
+        onUpdateFiles(index) 
+        //actually use same index as passed so maybe this isn't necessary
+        // onUpdateFiles();
+    };
+
+    const handleRemoveExistingProfileImage = (index: number) => {
+        const imageToRemove = authUser.profileImages?.[index];
+        if (!imageToRemove) return;
+
+        setRemovedImages((prev) => [...prev, imageToRemove.publicID]);
+        setExistingProfileImages((prev) => prev.filter((_, i) => i !== index))
+    };
+
+    return {
+        profileImages, 
+        existingProfileImages,
+        removedImages,
+        handleProfileImagesChange,
+        handleRemovePreviewProfileImage,
+        handleRemoveExistingProfileImage
+    }
+}
+
+export default useProfileImages;

--- a/client/src/features/shared/utils/data.ts
+++ b/client/src/features/shared/utils/data.ts
@@ -1,28 +1,22 @@
 import { SignUpFormInterface } from '../../auth/auth.interfaces';
-import { GalleryImageInterface } from '../../farmer/farmer.interface';
 import { CategoryItemPropsInterface } from '../interfaces';
 
-import fruit from '../../../assets/categories/fruit.svg';
+import grape from '../../../assets/categories/grape.svg';
 import vegetables from '../../../assets/categories/vegetables.svg';
+import dairyProducts from '../../../assets/categories/cheese.svg';
+import wheat from '../../../assets/categories/wheat.svg';
+import jam from '../../../assets/categories/jam-jar.svg';
+import eggs from '../../../assets/categories/eggs.svg';
+import herbs from '../../../assets/categories/herbs.svg';
 
 import background1 from '../../../assets/farmers/bg1.jpg';
 import avatar1 from '../../../assets/farmers/avatar1.jpg';
 import background2 from '../../../assets/farmers/bg2.jpg';
 import avatar2 from '../../../assets/farmers/avatar2.jpg';
 
-import gallery1 from '../../../assets/farmers/gallery/Card1.jpg';
-import gallery2 from '../../../assets/farmers/gallery/Card2.jpg';
-import gallery3 from '../../../assets/farmers/gallery/Card3.jpg';
-import gallery4 from '../../../assets/farmers/gallery/Card4.jpg';
-import gallery5 from '../../../assets/farmers/gallery/Card5.jpg';
-import gallery6 from '../../../assets/farmers/gallery/Card6.jpg';
-
-
-
 //from growvia-shared library(used in backend microservices)
 export const UNIT_TYPES = ["piece", "kg", "g", "liter", "ml"] as const;
 export type UnitType = (typeof UNIT_TYPES)[number];
-
 
 export const DEFAULT_IMAGE: {url:string, publicID:string} = {
     url: avatar1,
@@ -34,7 +28,7 @@ export const productCategories: CategoryItemPropsInterface[] = [
     {
         id: 'f1',
         name: "Fruit",
-        icon: fruit,
+        icon: grape,
     },
     {
         id: 'v2',
@@ -44,28 +38,28 @@ export const productCategories: CategoryItemPropsInterface[] = [
     {
         id: 'pd3',
         name: "Dairy Products",
-        icon: fruit,
+        icon: dairyProducts,
     },
     {
         id: 'g4',
         name: "Grains",
-        icon: fruit,
+        icon: wheat,
     },
     {
         id: 'ag5',
         name: "Artisan Goods",
-        icon: fruit,
+        icon: jam,
     },
     {
         id: 'e6',
         name: "Eggs",
-        icon: fruit,
+        icon: eggs,
     },
     {
         id: 'hb7',
         // name: "Herbs&Plants",
         name: "HerbsAndPlants",
-        icon: fruit,
+        icon: herbs,
     }
 ]
 
@@ -153,15 +147,8 @@ export const initalSignupUserData:SignUpFormInterface = {
     repeatPassword:'',
     userType: 'customer',
     phoneNumber: '',
-    // profilePicture: '',
-
     profileAvatarFile: '',
     backgroundImageFile: '',
-
-    // profileAvatar: {
-    //     url:'',
-    //     publicID:'',
-    // },
     // fullName: '', //FistName + LastName
     firstName: '',
     lastName: '',
@@ -189,13 +176,4 @@ export const SOCIAL = [
     { name: 'twitter', url:'' }, 
     { name: 'linkedin', url:'' }, 
     { name: 'tiktok', url:'' } 
-]
-
-export const farmerGalleryImages:GalleryImageInterface[] = [
-    { url: gallery1 , publicID: ''},
-    { url: gallery2 , publicID: ''},
-    { url: gallery3 , publicID: ''},
-    { url: gallery4 , publicID: ''},
-    { url: gallery5 , publicID: ''},
-    { url: gallery6 , publicID: ''}
 ]

--- a/server/microservices/gateway/src/controllers/users/farmer.ts
+++ b/server/microservices/gateway/src/controllers/users/farmer.ts
@@ -46,5 +46,5 @@ export async function newestFarmers(req:Request, res:Response):Promise<void>{
 
 export async function updateByID(req:Request, res:Response):Promise<void>{
     const response: AxiosResponse = await updateFarmerData(req.params.farmerID, req.body); 
-    res.status(200).json({ message:response.data.message, user:response.data.user});
+    res.status(200).json({ message:response.data.message, farmer:response.data.user});
 }

--- a/server/microservices/users/package-lock.json
+++ b/server/microservices/users/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "^8.17.0",
-        "@veckovn/growvia-shared": "^1.2.2",
+        "@veckovn/growvia-shared": "^1.2.4",
         "amqplib": "^0.10.3",
         "bcryptjs": "^3.0.0",
         "cloudinary": "^2.6.0",
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/@veckovn/growvia-shared": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@veckovn/growvia-shared/-/growvia-shared-1.2.2.tgz",
-      "integrity": "sha512-8/dMcPZP6IgQCdiNy+MBk657mUm9XygNOwbC6sYCwIqsVoyJpbW34WQb5XYNte21WGPocJW3nHIXLxm9ZW3jjg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@veckovn/growvia-shared/-/growvia-shared-1.2.4.tgz",
+      "integrity": "sha512-+dYfA+0z76NOGaTsTDNlQLe70ar0CpEcIIsoqSQq9Qqb5BfHI4entKKJsplBR31FaulwP5b6YYVTt4kL0y6zUw==",
       "license": "MIT",
       "dependencies": {
         "cloudinary": "^2.6.0",

--- a/server/microservices/users/package.json
+++ b/server/microservices/users/package.json
@@ -20,7 +20,7 @@
   "description": "",
   "dependencies": {
     "@elastic/elasticsearch": "^8.17.0",
-    "@veckovn/growvia-shared": "^1.2.2",
+    "@veckovn/growvia-shared": "^1.2.4",
     "amqplib": "^0.10.3",
     "bcryptjs": "^3.0.0",
     "cloudinary": "^2.6.0",

--- a/server/microservices/users/src/helper.ts
+++ b/server/microservices/users/src/helper.ts
@@ -1,5 +1,5 @@
 // import {winstonLogger, uploadImage, CustomerDocumentInterface, FarmerDocumentInterface } from "@veckovn/growvia-shared";
-import {winstonLogger, uploadImage } from "@veckovn/growvia-shared";
+import {winstonLogger, uploadImage, deleteImage } from "@veckovn/growvia-shared";
 import { Logger } from "winston";
 import { config } from "@users/config";
 import { v4 as uuidv4 } from 'uuid';
@@ -67,4 +67,29 @@ export const updateImageInCloudinary = async (
         // profilePicture 
         imageUrl 
     } 
+}
+
+export const deleteImageFromCloudinary = async (
+    publicID: string
+): Promise<boolean> => {
+    if(!publicID) return false;
+
+    try{
+        const removeResult = await deleteImage(publicID, true)
+
+        console.log("RemoveResult: ", removeResult);
+
+        if(removeResult?.result === 'ok'){
+            log.info(`User service: Image with publicID:${publicID} deleted from cloudinary`);
+            return true;
+        }
+        else {
+            log.warn(`User service: Failed to delete image ${publicID} (status: ${removeResult?.result})`);
+            return false;
+        }
+
+    } catch (err) {
+        log.log("error", `User service: error deleting image ${publicID} from cloudinary`);   
+        return false;
+    }
 }


### PR DESCRIPTION
### Description

1. Frontend
   - Split FarmerProfile.tsx into smaller, focused (single rensponsible) components
     - InfoForm
     - ProfileHeader
     - ProfileImages

   - Extracted reusable hooks:
     - useFarmerProfile (form + submit handling)
     - useProfileHeaderImages (avatar/background)
     - useProfileImages (gallery management)
   
   - Rename FarmerGalleryGrid to GalleryGrid component
 
2. Backend
   - Improve update farmer profile logic to handle avatar, background, and profile images more consistently, Ensured partial updates for nested fields like location.
   - Adding deleteImageFromCloudinary helper method for emoving image by publicID
   - Integrated image deletion when farmer removes profile images.


 
  