### PR TITLE
refactor: restrict product serach to name field only in Product Service

### DIFF
--- a/server/microservices/product/src/services/search.ts
+++ b/server/microservices/product/src/services/search.ts
@@ -82,13 +82,7 @@ const productsSerachByCategory = async(category: string): Promise<SearchResultIn
 }
 
 //refactor: unified product serach with full filter support
-// const productSearch = async(options: ProductSerachOptionsInterface):Promise<{products: ProductDocumentInterface[], total:number}>
 const productsSearch = async(options: ProductSearchOptionsInterface):Promise<SearchResultInterface> => {
-
-    console.log("OPTTT : ", options);
-
-    //or more structured (typed )
-    // const queries: ElasticQueryInterface[] = []
     const query: any = {
         bool: {
             must: [] as any[]
@@ -99,7 +93,8 @@ const productsSearch = async(options: ProductSearchOptionsInterface):Promise<Sea
     if(options.query){
         query.bool.must.push({
             query_string: {
-                fields: ['name', 'description', 'shortDescription','category', 'subCategories', 'tags'], //all fields participating in the filter
+                // fields: ['name', 'description', 'shortDescription','category', 'subCategories', 'tags'], //all fields participating in the filter
+                fields: ['name'], /// search only for product name
                 query: `*${options.query}*`
             }
         })


### PR DESCRIPTION
### Description
- Updated productsSearch query to search only in the name field
- Removed broader text search across description, category, subcategories, and tags
- Simplifies search results to be more relevant to product titles