### PR TITLE
Deploy Frontend Service (growvia-frontend) to Minikube with NGINX and Ingress Setup

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:23-alpine3.20 AS builder
+
+WORKDIR /app 
+COPY package*.json ./ 
+COPY tsconfig.json ./
+COPY vite.config.ts ./
+RUN npm ci
+COPY . . 
+RUN npm run build
+
+## Set up NGINX in our container (I'll not runinig it locally) 
+FROM nginx:stable-alpine
+##-> it will be run inside or container so the work directroy will be set (context from build file))
+
+## The first stage will exectue 'npm run build' and I'll get '/build' 
+WORKDIR /app
+COPY --from=builder /app/build /app/html 
+## in nginx.conf for 'server { root -> /app.html}'
+COPY nginx.conf /app
+RUN mkdir -p /app/run && apk add --no-cache bash && apk add --no-cache curl
+
+EXPOSE 80
+
+##These commands used to start the web server
+CMD ["nginx", "-c", "/app/nginx.conf"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,62 @@
+worker_processes 1;
+daemon off; #Because we want to run it in a Docker container
+#Telling Nginx to stay in the foreground
+
+## send erros to the console (standard out) ## we can send logs to file if we want
+error_log /dev/stdout info;
+pid       /app/run/nginx.pid; #save process ID taht will be creatad
+ 
+events {
+  worker_connections 1024;
+}
+
+http {
+  include         /etc/nginx/mime.types;
+  default_type    application/octet-stream;
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log      /dev/stdout main;
+  sendfile        on;
+  keepalive_timeout 65;
+
+  gzip              on;
+  gzip_http_version 1.0;
+  gzip_comp_level   5;
+  gzip_min_length   256;
+  gzip_proxied      any;
+  gzip_vary         on;
+  gzip_types        text/plain text/css application/json application/javascript text/xml application/xml+rss text/javascript;
+
+  server {
+    listen        80;
+    server_name   growvia.com;
+    root          /app/html;
+    gzip          on;
+
+    location ~* ^.+\.(css|svg)$ {
+      expires 7d;
+      try_files $uri =404;
+    }
+
+    location ~* ^.+\.(json|js)$ {
+      try_files $uri =404;
+    }
+
+    location ~* \.(?:jpg|jpeg|gif|png|webp|m4v|avi|mpg|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+      expires 1M;
+      access_log off;
+      add_header Cache-Control "must-revalidate";
+    }
+
+    location / {
+      index index.html;
+      try_files $uri /index.html;
+      add_header Cache-Control "must-revalidate";
+    }
+
+    location ~ .js.map$ {
+      return 404;
+    }
+  }
+}

--- a/client/src/sockets/socket.ts
+++ b/client/src/sockets/socket.ts
@@ -1,13 +1,11 @@
 import {io, Socket} from 'socket.io-client';
 
+const VITE_BASE_ENDPOINT = import.meta.env.VITE_BASE_ENDPOINT; //Backend endpoint -> Gateway Service
 let socket: Socket | null = null;
-
-const VITE_BASE_ENDPOINT='http://localhost:4000'; //Backend endpoint -> Gateway Service
 
 export const connectSocket = () => {
     if(socket) return socket; //only one instance ->
 
-    // socket = io(import.meta.env.VITE_BASE_ENDPOINT , { //importing from .env
     socket = io(VITE_BASE_ENDPOINT , {
         transports: ['websocket'],
         // secure:true, //only for 'https or wss
@@ -20,7 +18,6 @@ export const connectSocket = () => {
     registerSocketEvents(socket);
     
     return socket;
-
 }
 
 const registerSocketEvents = (sock: Socket) => {
@@ -35,12 +32,10 @@ const registerSocketEvents = (sock: Socket) => {
             // Server disconnected us, so reconnect manually
             sock.connect();
         }
-        // Otherwise, auto-reconnect will kick in
     });
 
     sock.on('connect_error', (error: Error) => {
         console.error(`Connection error: ${error.message}`);
-        // Auto-reconnect handles most cases
     });
 
     sock.on('error', (error) => {

--- a/client/src/store/api.ts
+++ b/client/src/store/api.ts
@@ -1,6 +1,7 @@
 import { BaseQueryFn, createApi, FetchArgs, fetchBaseQuery, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
 
-const BASE_ENDPOINT = 'http://localhost:4000';
+const BASE_ENDPOINT = import.meta.env.VITE_BASE_ENDPOINT;
+console.log("BASE EDNPOTIN: ", BASE_ENDPOINT);
 
 const baseQuery = fetchBaseQuery({
     //every request is sent to the API Gateway service 

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BASE_ENDPOINT: string
+  readonly VITE_STRIPE_PUBLISHABLE_KEY: string
+  readonly VITE_ELASTIC_APM_SERVER: string
+  // add more VITE_ variables here if you use them
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,7 +4,8 @@
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "outDir": "dist",
+    // "outDir": "dist", 
+    "outDir": "./build",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "paths": {

--- a/minikube/growvia-authentication/deployment.yaml
+++ b/minikube/growvia-authentication/deployment.yaml
@@ -43,7 +43,8 @@ spec:
           - name: RUNNING_IN_DOCKER
             value: '1'
           - name: CLIENT_URL
-            value: "http://localhost:3000"
+            # value: "http://localhost:3000"
+            value: "https://growvia.client"
           - name: API_GATEWAY_URL
             value: "http://growvia-gateway.production.svc.cluster.local:4000"
           - name: ELASTICSEARCH_URL

--- a/minikube/growvia-elastic/deployment.yaml
+++ b/minikube/growvia-elastic/deployment.yaml
@@ -29,12 +29,12 @@ spec:
           mountPath: /usr/share/elasticsearch/data
       containers:
         - name: growvia-elastic
-          image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0 #Image that is used in local Docker
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.15.3 
           imagePullPolicy: Always
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 30"]  # Graceful shutdown period
+                command: ["/bin/sh", "-c", "sleep 30"] #Graceful shutdown period
           resources:
             limits:
               cpu: 1500m

--- a/minikube/growvia-elastic/heartbeat.yaml
+++ b/minikube/growvia-elastic/heartbeat.yaml
@@ -205,7 +205,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: heartbeat
-        image: docker.elastic.co/beats/heartbeat:8.18.0
+        # image: docker.elastic.co/beats/heartbeat:8.18.0
+        image: docker.elastic.co/beats/heartbeat:8.15.3
         args: [
           "-c", "/usr/share/heartbeat/heartbeat.yml",
           "-e",

--- a/minikube/growvia-elastic/metricbeat.yaml
+++ b/minikube/growvia-elastic/metricbeat.yaml
@@ -283,7 +283,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:8.18.0
+        # image: docker.elastic.co/beats/metricbeat:8.18.0
+        image: docker.elastic.co/beats/metricbeat:8.15.3
         # system.hostfs must start with double dash -- (Was error with single dash)
         args: [
           "-c", "/etc/metricbeat.yml",

--- a/minikube/growvia-frontend/certs/generate_certs.sh
+++ b/minikube/growvia-frontend/certs/generate_certs.sh
@@ -1,0 +1,32 @@
+######################
+# Become a Certificate Authority
+######################
+
+# Generate private key
+openssl genrsa -des3 -out domain.key 2048
+# Generate root certificate
+openssl req -x509 -new -nodes -key domain.key -sha256 -days 825 -out domain.pem
+
+######################
+# Create CA-signed certs
+######################
+
+NAME=growvia.client # Domain name
+# Generate a private key
+openssl genrsa -out $NAME.key 2048
+# Create a certificate-signing request
+openssl req -new -key $NAME.key -out $NAME.csr
+# Create a config file for the extensions
+>$NAME.ext cat <<-EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $NAME # Be sure to include the domain name here because Common Name is not so commonly honoured by itself
+DNS.2 = api.$NAME # Optionally, add additional domains (I've added a subdomain here)
+# IP.1 = 192.168.0.13 # Optionally, add an IP address (if the connection which you have planned requires it)
+EOF
+# Create the signed certificate
+openssl x509 -req -in $NAME.csr -CA domain.pem -CAkey domain.key -CAcreateserial \
+-out $NAME.crt -days 825 -sha256 -extfile $NAME.ext

--- a/minikube/growvia-frontend/deployment.yaml
+++ b/minikube/growvia-frontend/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: growvia-frontend
+  namespace: production
+spec:
+  replicas: 1 
+  selector:
+    matchLabels:
+      app: growvia-frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      labels:
+        app: growvia-frontend
+    spec:
+      containers:
+      - name: growvia-frontend
+        image: veckovn/growvia-frontend:stable 
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+          requests:
+            cpu: 100m
+            # cpu: 250m
+            memory: 150Mi
+        ports:
+        - name: frontend ##specified as trargetPort in 'service.yaml'
+          containerPort: 80

--- a/minikube/growvia-frontend/ingress.yaml
+++ b/minikube/growvia-frontend/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: growvia-frontend-ingress
+  namespace: production
+spec:
+  #for minkube (localy) we’ll use nginx-ingress 
+  #in production could (AWS) be used the  loadBalancer will be used 
+  ingressClassName: nginx
+  defaultBackend:
+    service:
+      name: growvia-frontend
+      port: 
+        number: 80 #inside the service and NGINX config
+  tls:  #point certificates to the ingress
+    - hosts:
+      # - growvia.com 
+      - growvia.client  
+      secretName: frontend-growvia-tls #secret that is created
+  rules:
+  #Host domain - for local testing: http://growvia.client -> frontend 'browser' url
+  #this 'local/fake domen' has to be maped to Minikube IP address.
+  #more in documentations about mapping
+  # - host: growvia.com
+  - host: growvia.client
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: growvia-frontend
+            port: 
+              number: 80

--- a/minikube/growvia-frontend/service.yaml
+++ b/minikube/growvia-frontend/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: growvia-frontend
+  namespace: production
+spec:
+  #The ApiGateway will use ClusterIP as well but we’ll use Ingress
+  type: ClusterIP
+  selector:
+    app: growvia-frontend
+  ports:
+  - name: frontend
+    ##we using NGINX so port is 80 on it
+    port: 80
+    targetPort: frontend #defined in deployment.yaml
+    protocol: TCP

--- a/minikube/growvia-gateway/deployment.yaml
+++ b/minikube/growvia-gateway/deployment.yaml
@@ -39,7 +39,8 @@ spec:
           - name: RUNNING_IN_DOCKER
             value: '0'
           - name: CLIENT_URL
-            value: "http://localhost:3000"
+            # value: "http://localhost:3000"
+            value: "https://growvia.client"
           - name: ELASTICSEARCH_URL
             valueFrom:
               secretKeyRef:

--- a/minikube/growvia-kibana/deployment.yaml
+++ b/minikube/growvia-kibana/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: growvia-kibana
-          image: docker.elastic.co/kibana/kibana:8.18.0
+          image: docker.elastic.co/kibana/kibana:8.15.3
           resources:
             limits:
               memory: "1Gi"

--- a/minikube/growvia-order/deployment.yaml
+++ b/minikube/growvia-order/deployment.yaml
@@ -40,7 +40,8 @@ spec:
           - name: RUNNING_IN_DOCKER
             value: '0'
           - name: CLIENT_URL
-            value: "http://localhost:3000"
+            # value: "http://localhost:3000"
+            value: "https://growvia.client"
           - name: API_GATEWAY_URL
             value: "http://growvia-gateway.production.svc.cluster.local:4000"
           - name: ELASTICSEARCH_URL

--- a/minikube/growvia-payment/deployment.yaml
+++ b/minikube/growvia-payment/deployment.yaml
@@ -38,7 +38,8 @@ spec:
           - name: NODE_ENV
             value: 'production'
           - name: CLIENT_URL
-            value: "http://localhost:3000"
+            # value: "http://localhost:3000"
+            value: "https://growvia.client"
           - name: API_GATEWAY_URL
             value: "http://growvia-gateway.production.svc.cluster.local:4000"
           - name: ELASTICSEARCH_URL

--- a/minikube/growvia-product/deployment.yaml
+++ b/minikube/growvia-product/deployment.yaml
@@ -38,7 +38,8 @@ spec:
           - name: NODE_ENV
             value: 'production'
           - name: CLIENT_URL
-            value: "http://localhost:3000"
+            # value: "http://localhost:3000"
+            value: "https://growvia.client"
           - name: API_GATEWAY_URL
             value: "http://growvia-gateway.production.svc.cluster.local:4000"
           - name: ELASTICSEARCH_URL

--- a/minikube/growvia-users/deployment.yaml
+++ b/minikube/growvia-users/deployment.yaml
@@ -38,7 +38,8 @@ spec:
           - name: NODE_ENV
             value: 'production'
           - name: CLIENT_URL
-            value: "http://localhost:3000"
+            # value: "http://localhost:3000"
+            value: "https://growvia.client"
           - name: API_GATEWAY_URL
             value: "http://growvia-gateway.production.svc.cluster.local:4000"
           - name: ELASTICSEARCH_URL


### PR DESCRIPTION
### Description
This PR introduces the complete configuration and deployment setup for the growvia-frontend service in the Minikube Kubernetes cluster.
It includes Docker and NGINX setup for serving the frontend app, Kubernetes manifests for deployment, service, and ingress, as well as local HTTPS certificate generation `generate_certs.sh' for the growvia.client domain.
Additionally, it updates environment variables across backend services to use the new client URL and fixes versioning issues with Elasticsearch and Kibana.

### Changes
- Added Dockerfile and nginx.conf for frontend container build
- Configured TypeScript output directory from `dist` to `./build`.
- Fixed TypeScript .env import errors by defining vite-env.d.ts and refactoring socket.ts and api.ts to use environment-based VITE_BASE_ENDPOINT.
- Added Kubernetes manifests:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
- Added certs/ folder with generate_certs.sh script for HTTPS setup.
- Updated backend pods’ CLIENT_URL to https://growvia.client.
- Fixed Elasticsearch restart issue by downgrading image from 8.18.0 → 8.15.3 (with matching Kibana).
